### PR TITLE
Add REST API

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'celery',
-        'django',
+        'django==3.0.9',
         'django-admin-display',
         'django-allauth',
         'django-composed-configuration',

--- a/shapeworks_cloud/core/rest.py
+++ b/shapeworks_cloud/core/rest.py
@@ -1,0 +1,58 @@
+from rest_framework.pagination import PageNumberPagination
+from rest_framework.permissions import IsAuthenticatedOrReadOnly
+from rest_framework.viewsets import ModelViewSet
+
+from shapeworks_cloud.core.models import Dataset, Groomed, Particles, Segmentation, ShapeModel
+from shapeworks_cloud.core.serializers import (
+    DatasetSerializer,
+    GroomedSerializer,
+    ParticlesSerializer,
+    SegmentationSerializer,
+    ShapeModelSerializer,
+)
+
+
+class Pagination(PageNumberPagination):
+    page_size = 25
+    max_page_size = 100
+    page_size_query_param = 'page_size'
+
+
+class DatasetViewSet(ModelViewSet):
+    permission_classes = [IsAuthenticatedOrReadOnly]
+    serializer_class = DatasetSerializer
+    pagination_class = Pagination
+
+    queryset = Dataset.objects.all()
+
+
+class SegmentationViewSet(ModelViewSet):
+    permission_classes = [IsAuthenticatedOrReadOnly]
+    serializer_class = SegmentationSerializer
+    pagination_class = Pagination
+
+    queryset = Segmentation.objects.all()
+
+
+class GroomedViewSet(ModelViewSet):
+    permission_classes = [IsAuthenticatedOrReadOnly]
+    serializer_class = GroomedSerializer
+    pagination_class = Pagination
+
+    queryset = Groomed.objects.all()
+
+
+class ShapeModelViewSet(ModelViewSet):
+    permission_classes = [IsAuthenticatedOrReadOnly]
+    serializer_class = ShapeModelSerializer
+    pagination_class = Pagination
+
+    queryset = ShapeModel.objects.all()
+
+
+class ParticlesViewSet(ModelViewSet):
+    permission_classes = [IsAuthenticatedOrReadOnly]
+    serializer_class = ParticlesSerializer
+    pagination_class = Pagination
+
+    queryset = Particles.objects.all()

--- a/shapeworks_cloud/core/serializers.py
+++ b/shapeworks_cloud/core/serializers.py
@@ -1,0 +1,65 @@
+from rest_framework import serializers
+
+from shapeworks_cloud.core.models import Dataset, Groomed, Particles, Segmentation, ShapeModel
+
+
+class DatasetSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Dataset
+        fields = [
+            'name',
+            'created',
+            'modified',
+        ]
+        read_only_fields = ['created']
+
+
+class SegmentationSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Segmentation
+        fields = [
+            'name',
+            'blob',
+            'created',
+            'modified',
+        ]
+        read_only_fields = ['created']
+
+
+class GroomedSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Groomed
+        fields = [
+            'name',
+            'blob',
+            'created',
+            'modified',
+        ]
+        read_only_fields = ['created']
+
+
+class ShapeModelSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ShapeModel
+        fields = [
+            'name',
+            'analyze',
+            'correspondence',
+            'transform',
+            'magic_number',
+            'created',
+            'modified',
+        ]
+        read_only_fields = ['created']
+
+
+class ParticlesSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Particles
+        fields = [
+            'name',
+            'blob',
+            'created',
+            'modified',
+        ]
+        read_only_fields = ['created']

--- a/shapeworks_cloud/core/serializers.py
+++ b/shapeworks_cloud/core/serializers.py
@@ -7,6 +7,7 @@ class DatasetSerializer(serializers.ModelSerializer):
     class Meta:
         model = Dataset
         fields = [
+            'id',
             'name',
             'created',
             'modified',
@@ -18,6 +19,7 @@ class SegmentationSerializer(serializers.ModelSerializer):
     class Meta:
         model = Segmentation
         fields = [
+            'id',
             'name',
             'blob',
             'created',
@@ -30,6 +32,7 @@ class GroomedSerializer(serializers.ModelSerializer):
     class Meta:
         model = Groomed
         fields = [
+            'id',
             'name',
             'blob',
             'created',
@@ -42,6 +45,7 @@ class ShapeModelSerializer(serializers.ModelSerializer):
     class Meta:
         model = ShapeModel
         fields = [
+            'id',
             'name',
             'analyze',
             'correspondence',
@@ -57,6 +61,7 @@ class ParticlesSerializer(serializers.ModelSerializer):
     class Meta:
         model = Particles
         fields = [
+            'id',
             'name',
             'blob',
             'created',


### PR DESCRIPTION
To use the drf-extensions ExtendedSimpleRouter, which IMHO is much cleaner for nested data models than SimpleRouter, we need to pin django to 3.0.9 because of a bug in drf-extensions.