### PR TITLE
Add metadata processing functions

### DIFF
--- a/shapeworks_cloud/core/metadata.py
+++ b/shapeworks_cloud/core/metadata.py
@@ -1,0 +1,59 @@
+"""
+Methods and constants for manipulating metadata in filenames.
+
+For the purposes of this module, "patterns" are basically f-strings which are used to associate
+bits of filenames with bits of metadata.
+The only allowed variable names are the members of METADATA_FIELDS, i.e. '{subject}'.
+Patterns may also include formatting information, for example '{subject:04}.txt', which will match the
+filenames '0000.txt', '0001.txt', '9999.txt', etc. but will not match '1.txt'.
+"""
+
+import re
+from typing import Dict
+
+# TODO add more fields
+# Fields need to be mapped from strings to however they will be used and stored
+_METADATA_FIELD_TYPE_CONVERSIONS = {
+    'subject': lambda subject: int(subject),
+}
+METADATA_FIELDS = list(_METADATA_FIELD_TYPE_CONVERSIONS.keys())
+
+
+def pattern_as_regex(pattern: str):
+    """Format a user specified pattern as a regular expression."""
+    for field in METADATA_FIELDS:
+        # This regex should match {field} and {field:expression}
+        field_regex = re.compile(f'{{{ field }(?::([^{{}}]+))?}}')
+        instances = field_regex.findall(pattern)
+        if len(instances) == 0:
+            continue
+        if len(instances) > 1:
+            raise ValueError(f'Multiple definitions of {field}')
+        pattern = re.sub(field_regex, f'(?P<{field}>\\\\S+)', pattern)
+    return re.compile(pattern)
+
+
+def extract_metadata(pattern: str, filename: str):
+    """Extract the metadata from a filename using the given pattern."""
+    regex = pattern_as_regex(pattern)
+    match = regex.fullmatch(filename)
+    if match is None:
+        raise ValueError(f'File {filename} does not match pattern {pattern}')
+    metadata_strings = match.groupdict()
+    return {
+        field: _METADATA_FIELD_TYPE_CONVERSIONS[field](metadata_strings[field])
+        for field in metadata_strings
+    }
+
+
+def generate_filename(pattern: str, metadata: Dict[str, any]):
+    """Generate the filename associated with a set of metadata using the given pattern."""
+    return pattern.format(**metadata)
+
+
+def validate_filename(pattern: str, filename: str):
+    """Validate that a filename matches the given pattern."""
+    metadata = extract_metadata(pattern, filename)
+    new_filename = generate_filename(pattern, metadata)
+    if filename != new_filename:
+        raise ValueError(f'{filename} does not match generated {new_filename}')

--- a/shapeworks_cloud/core/metadata.py
+++ b/shapeworks_cloud/core/metadata.py
@@ -48,7 +48,10 @@ def extract_metadata(pattern: str, filename: str):
 
 def generate_filename(pattern: str, metadata: Dict[str, any]):
     """Generate the filename associated with a set of metadata using the given pattern."""
-    return pattern.format(**metadata)
+    try:
+        return pattern.format(**metadata)
+    except KeyError as e:
+        raise ValueError(e)
 
 
 def validate_filename(pattern: str, filename: str):

--- a/shapeworks_cloud/core/metadata.py
+++ b/shapeworks_cloud/core/metadata.py
@@ -57,3 +57,11 @@ def validate_filename(pattern: str, filename: str):
     new_filename = generate_filename(pattern, metadata)
     if filename != new_filename:
         raise ValueError(f'{filename} does not match generated {new_filename}')
+
+
+def validate_metadata(pattern: str, metadata: Dict[str, any]):
+    """Validate that a filename matches the given pattern."""
+    filename = generate_filename(pattern, metadata)
+    new_metadata = extract_metadata(pattern, filename)
+    if metadata != new_metadata:
+        raise ValueError(f'{metadata} does not match generated {new_metadata}')

--- a/shapeworks_cloud/core/metadata.py
+++ b/shapeworks_cloud/core/metadata.py
@@ -4,8 +4,8 @@ Methods and constants for manipulating metadata in filenames.
 For the purposes of this module, "patterns" are basically f-strings which are used to associate
 bits of filenames with bits of metadata.
 The only allowed variable names are the members of METADATA_FIELDS, i.e. '{subject}'.
-Patterns may also include formatting information, for example '{subject:04}.txt', which will match the
-filenames '0000.txt', '0001.txt', '9999.txt', etc. but will not match '1.txt'.
+Patterns may also include formatting information, for example '{subject:04}.txt', which will match
+the filenames '0000.txt', '0001.txt', '9999.txt', etc. but will not match '1.txt'.
 """
 
 import re

--- a/shapeworks_cloud/core/tests/test_metadata.py
+++ b/shapeworks_cloud/core/tests/test_metadata.py
@@ -21,11 +21,8 @@ def test_pattern_as_regex(pattern, regex):
 
 
 def test_pattern_as_regex_double_definitions():
-    try:
+    with pytest.raises(ValueError, match='Multiple definitions of subject'):
         metadata.pattern_as_regex(r'{subject}{subject}')
-        raise Exception('Expected an exception')
-    except ValueError as e:
-        assert e.args == ('Multiple definitions of subject',)
 
 
 @pytest.mark.parametrize(
@@ -49,11 +46,8 @@ def test_extract_metadata(pattern, filename, expected):
     ],
 )
 def test_extract_metadata_error(pattern, filename, expected):
-    try:
+    with pytest.raises(ValueError, match=re.escape(expected)):
         metadata.extract_metadata(pattern, filename)
-        raise Exception('Expected an exception')
-    except ValueError as e:
-        assert e.args == (expected,)
 
 
 @pytest.mark.parametrize(
@@ -80,11 +74,8 @@ def test_validate_filename(pattern, filename):
     ],
 )
 def test_validate_filename_error(pattern, filename, expected):
-    try:
+    with pytest.raises(ValueError, match=re.escape(expected)):
         metadata.validate_filename(pattern, filename)
-        raise Exception('Expected an exception')
-    except ValueError as e:
-        assert e.args == (expected,)
 
 
 @pytest.mark.parametrize(
@@ -109,8 +100,5 @@ def test_validate_metadata(pattern, _metadata):
     ],
 )
 def test_validate_metadata_error(pattern, _metadata, expected):
-    try:
+    with pytest.raises(ValueError, match=re.escape(expected)):
         metadata.validate_metadata(pattern, _metadata)
-        raise Exception('Expected an exception')
-    except ValueError as e:
-        assert e.args == (expected,)

--- a/shapeworks_cloud/core/tests/test_metadata.py
+++ b/shapeworks_cloud/core/tests/test_metadata.py
@@ -50,6 +50,11 @@ def test_extract_metadata_error(pattern, filename, expected):
         metadata.extract_metadata(pattern, filename)
 
 
+def test_generate_filename_error():
+    with pytest.raises(ValueError, match='subject'):
+        metadata.generate_filename('{subject}', {})
+
+
 @pytest.mark.parametrize(
     'pattern,filename',
     [

--- a/shapeworks_cloud/core/tests/test_metadata.py
+++ b/shapeworks_cloud/core/tests/test_metadata.py
@@ -85,3 +85,32 @@ def test_validate_filename_error(pattern, filename, expected):
         raise Exception('Expected an exception')
     except ValueError as e:
         assert e.args == (expected,)
+
+
+@pytest.mark.parametrize(
+    'pattern,_metadata',
+    [
+        (r'abc', {}),
+        (r'{subject}', {'subject': 1}),
+        (r'ellipsoid_{subject}_L.nrrd', {'subject': 42}),
+        (r'{subject:d}', {'subject': 2}),
+        (r'{subject:03}', {'subject': 0}),
+    ],
+)
+def test_validate_metadata(pattern, _metadata):
+    metadata.validate_metadata(pattern, _metadata)
+
+
+@pytest.mark.parametrize(
+    'pattern,_metadata,expected',
+    [
+        (r'{subject}{subject}', {'subject': None}, 'Multiple definitions of subject'),
+        (r'{subject}', {'subject': 'foo'}, "invalid literal for int() with base 10: 'foo'"),
+    ],
+)
+def test_validate_metadata_error(pattern, _metadata, expected):
+    try:
+        metadata.validate_metadata(pattern, _metadata)
+        raise Exception('Expected an exception')
+    except ValueError as e:
+        assert e.args == (expected,)

--- a/shapeworks_cloud/core/tests/test_metadata.py
+++ b/shapeworks_cloud/core/tests/test_metadata.py
@@ -1,0 +1,87 @@
+import re
+
+import pytest
+
+from shapeworks_cloud.core import metadata
+
+
+@pytest.mark.parametrize(
+    'pattern,regex',
+    [
+        (r'abc', r'abc'),
+        (r'{subject}', r'(?P<subject>\S+)'),
+        (r'{subject:x}', r'(?P<subject>\S+)'),
+        (r'pre{subject}post', r'pre(?P<subject>\S+)post'),
+        (r'pre{subject:x}post', r'pre(?P<subject>\S+)post'),
+        (r'{undefined}', r'{undefined}'),
+    ],
+)
+def test_pattern_as_regex(pattern, regex):
+    assert metadata.pattern_as_regex(pattern) == re.compile(regex)
+
+
+def test_pattern_as_regex_double_definitions():
+    try:
+        metadata.pattern_as_regex(r'{subject}{subject}')
+        raise Exception('Expected an exception')
+    except ValueError as e:
+        assert e.args == ('Multiple definitions of subject',)
+
+
+@pytest.mark.parametrize(
+    'pattern,filename,expected',
+    [
+        (r'abc', r'abc', {}),
+        (r'{subject}', r'1', {'subject': 1}),
+        (r'ellipsoid_{subject}_L.nrrd', 'ellipsoid_42_L.nrrd', {'subject': 42}),
+    ],
+)
+def test_extract_metadata(pattern, filename, expected):
+    assert metadata.extract_metadata(pattern, filename) == expected
+
+
+@pytest.mark.parametrize(
+    'pattern,filename,expected',
+    [
+        (r'{subject}{subject}', None, 'Multiple definitions of subject'),
+        (r'a', r'b', 'File b does not match pattern a'),
+        (r'{subject}', r'foo', "invalid literal for int() with base 10: 'foo'"),
+    ],
+)
+def test_extract_metadata_error(pattern, filename, expected):
+    try:
+        metadata.extract_metadata(pattern, filename)
+        raise Exception('Expected an exception')
+    except ValueError as e:
+        assert e.args == (expected,)
+
+
+@pytest.mark.parametrize(
+    'pattern,filename',
+    [
+        (r'abc', r'abc'),
+        (r'{subject}', r'1'),
+        (r'ellipsoid_{subject}_L.nrrd', 'ellipsoid_42_L.nrrd'),
+        (r'{subject:d}', r'2'),
+        (r'{subject:03}', r'000'),
+    ],
+)
+def test_validate_filename(pattern, filename):
+    metadata.validate_filename(pattern, filename)
+
+
+@pytest.mark.parametrize(
+    'pattern,filename,expected',
+    [
+        (r'{subject}{subject}', None, 'Multiple definitions of subject'),
+        (r'a', r'b', 'File b does not match pattern a'),
+        (r'{subject}', r'foo', "invalid literal for int() with base 10: 'foo'"),
+        (r'{subject:03}', '1', '1 does not match generated 001'),
+    ],
+)
+def test_validate_filename_error(pattern, filename, expected):
+    try:
+        metadata.validate_filename(pattern, filename)
+        raise Exception('Expected an exception')
+    except ValueError as e:
+        assert e.args == (expected,)


### PR DESCRIPTION
The f-strings plan will work for user defined patterns. Generating a filename from metadata is as trivial as invoking `pattern.format(**metadata)`. Extracting metadata from a filename involves converting the pattern into a regex with named capturing groups and doing some type conversions.

I put this logic into `shapeworks_cloud.core.metadata` for now. This code will need to be called from `swcc`, so maybe this should be moved into a 3rd package, or maybe into `swcc` which would be a dependency of `shapeworks_cloud`. 