### PR TITLE
Metadata rest

### DIFF
--- a/shapeworks_cloud/core/rest.py
+++ b/shapeworks_cloud/core/rest.py
@@ -3,7 +3,7 @@ from rest_framework.mixins import DestroyModelMixin, UpdateModelMixin
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.response import Response
-from rest_framework.viewsets import ReadOnlyModelViewSet, ModelViewSet
+from rest_framework.viewsets import ModelViewSet, ReadOnlyModelViewSet
 from rest_framework_extensions.mixins import NestedViewSetMixin
 
 from shapeworks_cloud.core.models import Dataset, Groomed, Particles, Segmentation, ShapeModel

--- a/shapeworks_cloud/core/rest.py
+++ b/shapeworks_cloud/core/rest.py
@@ -22,7 +22,7 @@ class Pagination(PageNumberPagination):
     page_size_query_param = 'page_size'
 
 
-class DatasetViewSet(ReadOnlyModelViewSet):
+class DatasetViewSet(ModelViewSet):
     permission_classes = [IsAuthenticatedOrReadOnly]
     serializer_class = DatasetSerializer
     pagination_class = Pagination

--- a/shapeworks_cloud/core/rest.py
+++ b/shapeworks_cloud/core/rest.py
@@ -1,6 +1,10 @@
+from django.shortcuts import get_object_or_404
+from rest_framework.mixins import DestroyModelMixin, UpdateModelMixin
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
-from rest_framework.viewsets import ReadOnlyModelViewSet
+from rest_framework.response import Response
+from rest_framework.viewsets import ReadOnlyModelViewSet, ModelViewSet
+from rest_framework_extensions.mixins import NestedViewSetMixin
 
 from shapeworks_cloud.core.models import Dataset, Groomed, Particles, Segmentation, ShapeModel
 from shapeworks_cloud.core.serializers import (
@@ -26,33 +30,71 @@ class DatasetViewSet(ReadOnlyModelViewSet):
     queryset = Dataset.objects.all()
 
 
-class SegmentationViewSet(ReadOnlyModelViewSet):
+class BaseViewSet(
+    NestedViewSetMixin,
+    DestroyModelMixin,
+    UpdateModelMixin,
+    ReadOnlyModelViewSet,
+):
     permission_classes = [IsAuthenticatedOrReadOnly]
-    serializer_class = SegmentationSerializer
     pagination_class = Pagination
 
+    # TODO this was the best way I could find to populate foreign keys.
+    # Each ViewSet defines it's own create() which locates the parent entity, then delegates
+    # to this method to handle the rest.
+    def _create(self, request, **kwargs):
+        serializer = self.serializer_class(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        instance = self.model(**serializer.validated_data, **kwargs)
+        instance.save()
+
+        return Response(status=201)
+
+
+class SegmentationViewSet(BaseViewSet):
+    serializer_class = SegmentationSerializer
+    model = Segmentation
     queryset = Segmentation.objects.all()
 
+    def create(self, request, parent_lookup_dataset__pk):
+        dataset = get_object_or_404(Dataset, pk=parent_lookup_dataset__pk)
+        return self._create(request, dataset=dataset)
 
-class GroomedViewSet(ReadOnlyModelViewSet):
-    permission_classes = [IsAuthenticatedOrReadOnly]
+
+class GroomedViewSet(BaseViewSet):
     serializer_class = GroomedSerializer
-    pagination_class = Pagination
-
+    model = Groomed
     queryset = Groomed.objects.all()
 
+    def create(self, request, parent_lookup_dataset__pk):
+        dataset = get_object_or_404(Dataset, pk=parent_lookup_dataset__pk)
+        return self._create(request, dataset=dataset)
 
-class ShapeModelViewSet(ReadOnlyModelViewSet):
-    permission_classes = [IsAuthenticatedOrReadOnly]
+
+class ShapeModelViewSet(BaseViewSet):
     serializer_class = ShapeModelSerializer
-    pagination_class = Pagination
-
+    model = ShapeModel
     queryset = ShapeModel.objects.all()
 
+    def create(self, request, parent_lookup_dataset__pk):
+        dataset = get_object_or_404(Dataset, pk=parent_lookup_dataset__pk)
+        return self._create(request, dataset=dataset)
 
-class ParticlesViewSet(ReadOnlyModelViewSet):
-    permission_classes = [IsAuthenticatedOrReadOnly]
+
+class ParticlesViewSet(BaseViewSet):
     serializer_class = ParticlesSerializer
-    pagination_class = Pagination
-
+    model = Particles
     queryset = Particles.objects.all()
+
+    def create(
+        self,
+        request,
+        parent_lookup_shape_model__dataset__pk,
+        parent_lookup_shape_model__pk,
+    ):
+        shape_model = get_object_or_404(
+            ShapeModel,
+            pk=parent_lookup_shape_model__pk,
+            dataset__pk=parent_lookup_shape_model__dataset__pk,
+        )
+        return self._create(request, shape_model=shape_model)

--- a/shapeworks_cloud/core/serializers.py
+++ b/shapeworks_cloud/core/serializers.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 
+from shapeworks_cloud.core.metadata import METADATA_FIELDS
 from shapeworks_cloud.core.models import Dataset, Groomed, Particles, Segmentation, ShapeModel
 
 
@@ -18,33 +19,38 @@ class DatasetSerializer(serializers.ModelSerializer):
         read_only_fields = ['created']
 
 
-class SegmentationSerializer(serializers.ModelSerializer):
+class BlobModelSerializer(serializers.ModelSerializer):
+    # The default blob field is readonly, but we need it to be required for model creation
+    blob = serializers.CharField()
+
     class Meta:
+        abstract = True
+        fields = [
+            'id',
+            'name',
+            'blob',
+            'created',
+            'modified',
+        ] + METADATA_FIELDS
+        read_only_fields = ['created']
+
+
+class SegmentationSerializer(BlobModelSerializer):
+    class Meta(BlobModelSerializer.Meta):
         model = Segmentation
-        fields = [
-            'id',
-            'name',
-            'blob',
-            'created',
-            'modified',
-        ]
-        read_only_fields = ['created']
 
 
-class GroomedSerializer(serializers.ModelSerializer):
-    class Meta:
+class GroomedSerializer(BlobModelSerializer):
+    class Meta(BlobModelSerializer.Meta):
         model = Groomed
-        fields = [
-            'id',
-            'name',
-            'blob',
-            'created',
-            'modified',
-        ]
-        read_only_fields = ['created']
 
 
 class ShapeModelSerializer(serializers.ModelSerializer):
+    # The default S3FFs are readonly, but we need them to be required for model creation
+    analyze = serializers.CharField()
+    correspondence = serializers.CharField()
+    transform = serializers.CharField()
+
     class Meta:
         model = ShapeModel
         fields = [
@@ -60,14 +66,6 @@ class ShapeModelSerializer(serializers.ModelSerializer):
         read_only_fields = ['created']
 
 
-class ParticlesSerializer(serializers.ModelSerializer):
-    class Meta:
+class ParticlesSerializer(BlobModelSerializer):
+    class Meta(BlobModelSerializer.Meta):
         model = Particles
-        fields = [
-            'id',
-            'name',
-            'blob',
-            'created',
-            'modified',
-        ]
-        read_only_fields = ['created']

--- a/shapeworks_cloud/settings.py
+++ b/shapeworks_cloud/settings.py
@@ -24,6 +24,10 @@ class ShapeworksCloudMixin(ConfigMixin):
             'shapeworks_cloud.core.apps.CoreConfig',
             's3_file_field',
         ]
+        configuration.REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'] += [
+            # Required for swagger logins
+            'rest_framework.authentication.SessionAuthentication',
+        ]
 
 
 class DevelopmentConfiguration(ShapeworksCloudMixin, DevelopmentBaseConfiguration):


### PR DESCRIPTION
This should be everything required for the CLI to upload to Django.

Assuming the S3FF python client does roughly the same thing as the JS client, you should get a `field_value` at the end of upload which is a signed string. Passing that as `field_value` to any of the create (POST) or update (PUT) endpoints will automatically unwrap it and assign the `blob` field on the model appropriately.

I'm not sure if that will work on PATCH, but we'll cross that bridge when we come to it.