### PR TITLE
Allow pattern edit

### DIFF
--- a/shapeworks_cloud/core/forms.py
+++ b/shapeworks_cloud/core/forms.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.core.exceptions import ValidationError
 
-from shapeworks_cloud.core.metadata import METADATA_FIELDS, validate_metadata
+from shapeworks_cloud.core.metadata import METADATA_FIELDS, validate_filename
 from shapeworks_cloud.core.models import Dataset, Groomed, Particles, Segmentation, ShapeModel
 
 
@@ -14,7 +14,7 @@ class DatasetForm(forms.ModelForm):
         pattern = self.cleaned_data[pattern_name]
         try:
             for instance in queryset.all():
-                validate_metadata(pattern, instance.metadata)
+                validate_filename(pattern, instance.name)
         except ValueError as e:
             raise ValidationError(e)
         return pattern

--- a/shapeworks_cloud/core/models.py
+++ b/shapeworks_cloud/core/models.py
@@ -76,10 +76,12 @@ class BlobModel(TimeStampedModel, models.Model):
         raise NotImplementedError()
 
     @property
+    def all_metadata(self):
+        return {field: self.__dict__[field] for field in METADATA_FIELDS}
+
+    @property
     def metadata(self):
-        return {
-            field: self.__dict__[field] for field in METADATA_FIELDS if self.__dict__[field] != ''
-        }
+        return {field: value for field, value in self.all_metadata.items() if value != ''}
 
     @property
     def metadata_values(self):
@@ -88,7 +90,7 @@ class BlobModel(TimeStampedModel, models.Model):
 
     @property
     def name(self):
-        return generate_filename(self.pattern, self.metadata)
+        return generate_filename(self.pattern, self.all_metadata)
 
     @property
     def formatted_size(self, base=1024, unit='B'):


### PR DESCRIPTION
There was a chicken and egg problem where edits to the pattern were not allowed because models did not have metadata specified yet, and edits to model metadata were not allowed because the pattern did not include those fields.

Now modifications to the pattern are allowed as long as they match the generated filenames. Upon applying the pattern the generated filename changes and the user needs to modify the metadata for all the models.