### PR TITLE
Download by subject

### DIFF
--- a/swcc/swcc/__init__.py
+++ b/swcc/swcc/__init__.py
@@ -135,10 +135,11 @@ def list_(ctx):
 
 
 @dataset.command(name='download', help='download a dataset')
-@click.argument('id_', type=int)
+@click.argument('id_', type=int, metavar='ID')
 @click.argument('dest', type=click.Path(exists=False, file_okay=False, dir_okay=True))
+@click.option('-s', '--subject-id', type=int, multiple=True)
 @click.pass_obj
-def download(ctx, id_: int, dest):
+def download(ctx, id_: int, dest, subject_id):
     dest = Path(dest)
     dest.mkdir(exist_ok=True)
     dataset = Dataset.from_id(ctx, id_)
@@ -146,12 +147,14 @@ def download(ctx, id_: int, dest):
     segmentations = Path(dest / 'segmentations')
     segmentations.mkdir(exist_ok=True, parents=True)
     for x in dataset.segmentations(ctx):
-        x.download(ctx, segmentations)
+        if (not subject_id) or (x.subject in subject_id):
+            x.download(ctx, segmentations)
 
     groomed = Path(dest / 'groomed')
     groomed.mkdir(exist_ok=True, parents=True)
     for x in dataset.groomed(ctx):
-        x.download(ctx, groomed)
+        if (not subject_id) or (x.subject in subject_id):
+            x.download(ctx, groomed)
 
     shape_models = Path(dest / 'shape_models')
     shape_models.mkdir(exist_ok=True, parents=True)
@@ -161,7 +164,8 @@ def download(ctx, id_: int, dest):
         particles = Path(shape_models / x.name / 'particles')
         particles.mkdir(exist_ok=True, parents=True)
         for particle in dataset.particles(ctx, x.id):
-            particle.download(ctx, particles)
+            if (not subject_id) or (particle.subject in subject_id):
+                particle.download(ctx, particles)
 
 
 def main():

--- a/swcc/swcc/models.py
+++ b/swcc/swcc/models.py
@@ -14,6 +14,11 @@ class BlobModel(BaseModel):
     id: int
     name: str
     blob: str
+    subject: int
+    particle_type: str
+    chirality: str
+    extension: str
+    grooming_steps: str
     created: datetime
     modified: datetime
 


### PR DESCRIPTION
The only way I could find to specify a list of numbers in click was an Option with `multiple=True`. To download subjects 4, 5 and 6, you would have to do `swcc dataset download -s 4 -s 5 -s 6 1337 /path/to/folder`. Hypothetically we could do a comma separated string, i.e. `swcc dataset download --subject-ids 4,5,6 1336 /path/to/folder`, but that seems clumsier to me.