### PR TITLE
Add force_create method to Dataset

### DIFF
--- a/swcc/swcc/models.py
+++ b/swcc/swcc/models.py
@@ -314,6 +314,12 @@ class Dataset(ApiModel):
             for mesh in subject.meshes:
                 yield mesh
 
+    def force_create(self):
+        old_dataset = Dataset.from_name(self.name)
+        if old_dataset is not None:
+            old_dataset.delete()
+        return self.create()
+
     def add_project(self, file: Path, keywords: str = '', description: str = '') -> Project:
         project = Project(
             file=file,


### PR DESCRIPTION
`force_create` method is an alternative to `create` that checks if a Dataset with that name already exists on the server, and deletes it if so. Note that this will also delete any Projects associated with that Dataset.

Fixes #99 