### PR TITLE
Add backup option to Dataset.force_create

### DIFF
--- a/swcc/swcc/models.py
+++ b/swcc/swcc/models.py
@@ -322,7 +322,7 @@ class Dataset(ApiModel):
         its name before creation.
         """
         old_dataset = Dataset.from_name(self.name)
-        if old_dataset is not None:
+        while old_dataset is not None:
             if not backup:
                 # Delete the old dataset to resolve the collision
                 old_dataset.delete()
@@ -339,6 +339,9 @@ class Dataset(ApiModel):
                 else:
                     # The old name had no suffix, so append "-v1"
                     self.name = f'{self.name}-v1'  # type: ignore
+            # We have a new name now, but that new name might also conflict.
+            # Keep looping until there is no conflict.
+            old_dataset = Dataset.from_name(self.name)
         return self.create()
 
     def add_project(self, file: Path, keywords: str = '', description: str = '') -> Project:


### PR DESCRIPTION
https://github.com/girder/shapeworks-cloud/pull/105#issuecomment-968994190
> We discussed also having a mode where we would keep previous versions. I image that this could add a parameter to the force_create method like backup=True, which, if the dataset exists under the current name, would rename it to the first available name suffixed with -v{number}, and then do the create. We could make that a separate PR.

@iyerkrithika21 backup option for `Dataset.force_create`. It prescribes that all Datasets be versioned like `whatever-v123`.