### PR TITLE
Bundle vue app

### DIFF
--- a/dev/django.Dockerfile
+++ b/dev/django.Dockerfile
@@ -7,6 +7,16 @@ RUN apt-get update && \
         libgl1-mesa-glx libxt6 libglib2.0-0 && \
     rm -rf /var/lib/apt/lists/*
 
+RUN curl -sL https://deb.nodesource.com/setup_16.x  | bash - && \
+    apt-get update && \
+    apt-get install --yes --no-install-recommends \
+    nodejs && \
+    npm install -g npm@latest && \
+    npm --version && \
+    node --version && \
+    npm install -g yarn && \
+    yarn --version
+
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 

--- a/shapeworks_cloud/settings.py
+++ b/shapeworks_cloud/settings.py
@@ -52,3 +52,8 @@ class ProductionConfiguration(ShapeworksCloudMixin, ProductionBaseConfiguration)
 
 class HerokuProductionConfiguration(ShapeworksCloudMixin, HerokuProductionBaseConfiguration):
     pass
+
+
+BASE_DIR = Path(__file__).resolve(strict=True).parent
+STATIC_ROOT = BASE_DIR / 'static'
+STATIC_URL = '/static/'

--- a/shapeworks_cloud/urls.py
+++ b/shapeworks_cloud/urls.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import include, path
 from drf_yasg import openapi
@@ -49,6 +50,7 @@ urlpatterns = [
     path('api/docs/swagger/', schema_view.with_ui('swagger'), name='docs-swagger'),
     path('api-token-auth/', obtain_auth_token),
 ]
+urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
 
 if settings.DEBUG:
     import debug_toolbar

--- a/web/shapeworks/tsconfig.json
+++ b/web/shapeworks/tsconfig.json
@@ -32,13 +32,14 @@
     ]
   },
   "include": [
-    "src/**/*.ts",
+    "Xsrc/**/*.ts",
     "src/**/*.tsx",
     "src/**/*.vue",
     "tests/**/*.ts",
     "tests/**/*.tsx",
     "src/reader/shape.js",
     "src/reader/points.js"
+
   ],
   "exclude": [
     "node_modules"

--- a/web/shapeworks/vue.config.js
+++ b/web/shapeworks/vue.config.js
@@ -4,6 +4,7 @@ module.exports = {
       warnings: false,
       errors: false,
     },
+    disableHostCheck: true,
   },
   chainWebpack: (config) => {
     // Add vtk.js shader loader
@@ -37,4 +38,8 @@ module.exports = {
   transpileDependencies: [
     'vuetify'
   ],
+  // in Django's TEMPLATE_DIRS
+  outputDir: '../../shapeworks_cloud/staticfiles',
+  // Django's STATIC_URL
+  assetsDir: '.',
 }

--- a/web/shapeworks/yarn.lock
+++ b/web/shapeworks/yarn.lock
@@ -2519,9 +2519,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001219:
-  version "1.0.30001223"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001223.tgz#39b49ff0bfb3ee3587000d2f66c47addc6e14443"
-  integrity sha512-k/RYs6zc/fjbxTjaWZemeSmOjO0JJV+KguOBA3NwPup8uzxM1cMhR2BD9XmO86GuqaqTCO8CgkgH9Rz//vdDiA==
+  version "1.0.30001303"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001303.tgz"
+  integrity sha512-/Mqc1oESndUNszJP0kx0UaQU9kEv9nNtJ7Kn8AdA0mNnH8eR1cj0kG+NbNuC1Wq/b21eA8prhKRA3bbkjONegQ==
 
 case-sensitive-paths-webpack-plugin@^2.3.0:
   version "2.4.0"


### PR DESCRIPTION
This is a somewhat hacky way to add the vue app to the django deployment at /static/index.html.  Ideally, we want to adjust it to serve as the root and handle templates within the vue app.

This exposes the models on the django admin panel.

This also temporarily disables typescript checking until an error with the router file is resolved.