### PR TITLE
Rendering bugs

### DIFF
--- a/web/shapeworks/src/components/ShapeViewer.vue
+++ b/web/shapeworks/src/components/ShapeViewer.vue
@@ -72,7 +72,9 @@ export default {
     },
   },
   data() {
-    return {};
+    return {
+      cachedMarchingCubes: {}
+    };
   },
   computed: {
     grid() {
@@ -225,9 +227,9 @@ export default {
       renderer.addActor(actor);
       this.vtk.pointMappers.push(mapper);
     },
-    addShapes(renderer, shapes) {
+    addShapes(renderer, label, shapes) {
       shapes.forEach(
-        (shape) => {
+        (shape, index) => {
           const mapper = vtkMapper.newInstance({
             colorMode: ColorMode.MAP_SCALARS,
           });
@@ -237,6 +239,8 @@ export default {
           actor.setMapper(mapper);
           if (shape.getClassName() == 'vtkPolyData'){
             mapper.setInputData(shape);
+          } else if (this.cachedMarchingCubes[`${label}_${index}`]) {
+            mapper.setInputData(this.cachedMarchingCubes[`${label}_${index}`])
           } else {
             const marchingCube = vtkImageMarchingCubes.newInstance({
               contourValue: 0.001,
@@ -245,6 +249,7 @@ export default {
             });
             marchingCube.setInputData(shape)
             mapper.setInputConnection(marchingCube.getOutputPort());
+            this.cachedMarchingCubes[`${label}_${index}`] = marchingCube.getOutputData()
           }
           renderer.addActor(actor);
         }
@@ -267,7 +272,7 @@ export default {
         this.labelCanvas.height * (1 - bounds[1]) - 20
       );
 
-      this.addShapes(renderer, shapes.map(({shape}) => shape));
+      this.addShapes(renderer, label, shapes.map(({shape}) => shape));
       const points = shapes.map(({points}) => points)
       if(points.length > 0 && points[0].getNumberOfPoints() > 0) this.addPoints(renderer, points[0]);
 

--- a/web/shapeworks/src/components/ShapeViewer.vue
+++ b/web/shapeworks/src/components/ShapeViewer.vue
@@ -160,28 +160,19 @@ export default {
     syncCameras(animation) {
       const targetRenderer = animation.pokedRenderer;
       const targetCamera = targetRenderer.getActiveCamera();
-      const positionDelta = targetCamera.getReferenceByName('position').map(
-        (datum, index) => datum - targetRenderer.__proto__.initialCameraPosition[index]
-      )
-      const newFocalPoint = targetCamera.getReferenceByName('focalPoint');
+      const newPosition = targetCamera.getReferenceByName('position');
       const newViewUp = targetCamera.getReferenceByName('viewUp');
       const newViewAngle = targetCamera.getReferenceByName('viewAngle');
+      const newClippingRange = targetCamera.getClippingRange();
       const otherRenderers = this.vtk.renderers.filter(
         (renderer) => renderer.getActiveCamera() !== targetCamera
       )
       otherRenderers.forEach((renderer) => {
         const camera = renderer.getActiveCamera();
-        const newPosition = renderer.__proto__.initialCameraPosition.map(
-          (datum, index) => datum + positionDelta[index]
-        )
         camera.setPosition(...newPosition)
-        camera.setFocalPoint(...newFocalPoint)
         camera.setViewUp(...newViewUp)
         camera.setViewAngle(newViewAngle)
-        // TODO: resetting the camera here means that renderers
-        // won't share pan and zoom
-        // but taking this off results in origin offset and clipping plane problems
-        renderer.resetCamera()
+        camera.setClippingRange(...newClippingRange)
       })
     },
     createColorFilter() {
@@ -283,7 +274,6 @@ export default {
       const camera = vtkCamera.newInstance();
       renderer.setActiveCamera(camera);
       renderer.resetCamera();
-      renderer.__proto__.initialCameraPosition = [...camera.getReferenceByName('position')]
     },
     renderGrid() {
       this.prepareLabelCanvas();


### PR DESCRIPTION
Resolves #144, resolves #148 

Thank you, @floryst, for your help!

The problem I ran into earlier with showing multiple domains in a renderer has also been fixed. The commit that broke it was the last. It was a matter of changing the key used in the dictionary for caching marching cubes outputs. The second shape was overwriting the first because the key was only the renderer label. Now that key also uses the index of the shape in the renderer.