### PR TITLE
Fix CI flake8 issue.

### DIFF
--- a/swcc/tox.ini
+++ b/swcc/tox.ini
@@ -10,7 +10,6 @@ envlist =
 skipsdist = true
 skip_install = true
 deps =
-    flake8
     flake8-black
     flake8-bugbear
     flake8-docstrings

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,6 @@ envlist =
 skipsdist = true
 skip_install = true
 deps =
-    flake8
     flake8-black
     flake8-bugbear
     flake8-docstrings


### PR DESCRIPTION
flake8-isort needs an update before it works with flake8 5.0.  By removing flake8 as an explicit dependency, pip properly figured out which versions can work.