### PR TITLE
Fix invocation of shapeworks commands

### DIFF
--- a/dev/django.Dockerfile
+++ b/dev/django.Dockerfile
@@ -22,7 +22,8 @@ RUN pip install -U pip && \
     pip install --editable /opt/django-project[dev] && \
     pip install --editable /opt/django-project/swcc
 
-RUN curl -L -o /tmp/shapeworks.tgz https://api.github.com/repos/SCIInstitute/ShapeWorks/tarball/dev-linux
+RUN export url=$(curl -s https://api.github.com/repos/SCIInstitute/ShapeWorks/releases | grep -o "http.*dev-linux.*${6:-tar.gz}"); \
+    curl -L -o /tmp/shapeworks.tgz $url
 RUN mkdir /opt/shapeworks && \
     tar -zxvf /tmp/shapeworks.tgz -C /opt/shapeworks --strip-components 1 && \
     rm /tmp/shapeworks.tgz

--- a/shapeworks_cloud/core/tasks.py
+++ b/shapeworks_cloud/core/tasks.py
@@ -28,8 +28,7 @@ def edit_swproj_section(filename, section_name, new_df):
     else:
         data[section_name] = new_contents
     data['data'] = [
-        {k: v.replace('../', '').replace('./', '') for k, v in row.items()}
-        for row in data['data']
+        {k: v.replace('../', '').replace('./', '') for k, v in row.items()} for row in data['data']
     ]
     with open(filename, 'w') as f:
         json.dump(data, f)

--- a/swcc/tox.ini
+++ b/swcc/tox.ini
@@ -10,6 +10,7 @@ envlist =
 skipsdist = true
 skip_install = true
 deps =
+    flake8<6
     flake8-black
     flake8-bugbear
     flake8-docstrings

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ envlist =
 skipsdist = true
 skip_install = true
 deps =
+    flake8<6
     flake8-black
     flake8-bugbear
     flake8-docstrings


### PR DESCRIPTION
When swcc switched to relative downloads only (ignoring "../" in path values), the invocation of shapeworks commands was broken. To compensate, before invoking the shapeworks command, the project file is edited to remove instances of "../".

Additionally, #214 made a change to the dockerfile that doesn't actually work. I thought I had found a static url that gave us the download we needed, but that tarball wasn't built, and the invocation of the commands was broken for that reason as well. This PR undoes that change.