### PR TITLE
This may fix the current heroku deployment.

### DIFF
--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -5,8 +5,8 @@ on:
       - master
 env:
   VUE_APP_OAUTH_CLIENT_ID: kNREkFvALDHTgTInKEdtNbvd6k9XUNN3dBytvaSr
-  VUE_APP_API_ROOT: https://www.shapeworks-cloud.org/
-  VUE_APP_OAUTH_API_ROOT: https://www.shapeworks-cloud.org/oauth/
+  VUE_APP_API_ROOT: https://app.shapeworks-cloud.org/
+  VUE_APP_OAUTH_API_ROOT: https://app.shapeworks-cloud.org/oauth/
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/shapeworks_cloud/settings.py
+++ b/shapeworks_cloud/settings.py
@@ -54,5 +54,5 @@ class ProductionConfiguration(ShapeworksCloudMixin, ProductionBaseConfiguration)
 
 
 class HerokuProductionConfiguration(ShapeworksCloudMixin, HerokuProductionBaseConfiguration):
-    ALLOWED_HOSTS = ['shapeworks-cloud.herokuapp.com', 'www.shapeworks-cloud.org']
+    ALLOWED_HOSTS = ['shapeworks-cloud.herokuapp.com', 'app.shapeworks-cloud.org']
     LOGIN_REDIRECT_URL = 'www.shapeworks-cloud.org'


### PR DESCRIPTION
Some urls were changed from app.shapeworks-cloud to www in PR #241; this changes them back.