### PR TITLE
Fix undefined error: load incorrect analysis data

### DIFF
--- a/web/shapeworks/src/store.ts
+++ b/web/shapeworks/src/store.ts
@@ -268,7 +268,7 @@ export async function switchTab(tabName: string){
     switch(tabName) {
         // add any other tab-switching updates here
         case 'analyze':
-            if (refreshedProject && !currentTasks.value[selectedProject.value.id]['analyze_task']) {
+            if (refreshedProject && !currentTasks.value[selectedProject.value.id]) {
                 analysis.value = refreshedProject.last_cached_analysis
             }
     }


### PR DESCRIPTION
Close #288 

Undefined error: `currentTasks.value[selectedProject.value.id] is undefined` causing previously cached analysis to load for every project until a new `optimize` is ran in the project.