### PR TITLE
Fix unused variables in Analysis refactor

### DIFF
--- a/web/shapeworks/src/components/Analysis/AnalysisTab.vue
+++ b/web/shapeworks/src/components/Analysis/AnalysisTab.vue
@@ -9,12 +9,7 @@ import { defineComponent, ref, computed, watch, provide } from '@vue/composition
 import Charts from './Charts.vue'
 import Groups from './Groups.vue'
 import PCA from './PCA.vue'
-
-export enum AnalysisTabs {
-    PCA = 0,
-    Groups,
-    Charts
-}
+import { AnalysisTabs } from './util';
 
 export default defineComponent({
     props: {
@@ -28,7 +23,7 @@ export default defineComponent({
         Groups,
         PCA
     },
-    setup(props) {
+    setup() {
         const openTab = ref(AnalysisTabs.PCA);
         const message = ref<string>();
         const currentlyCaching = ref<boolean>(false);

--- a/web/shapeworks/src/components/Analysis/Groups.vue
+++ b/web/shapeworks/src/components/Analysis/Groups.vue
@@ -3,7 +3,7 @@
 import { AnalysisGroup } from '@/types';
 import { Ref, computed, defineComponent, inject, ref, watch } from '@vue/composition-api';
 
-import { AnalysisTabs } from './AnalysisTab.vue';
+import { AnalysisTabs } from './util';
   
   export default defineComponent({
     props: {

--- a/web/shapeworks/src/components/Analysis/PCA.vue
+++ b/web/shapeworks/src/components/Analysis/PCA.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { analysis, analysisFileShown, cacheAllComparisons, currentAnalysisFileParticles, meanAnalysisFileParticles } from '@/store';
   import { computed, defineComponent, ref, Ref, watch, inject } from '@vue/composition-api';
-  import { AnalysisTabs } from './AnalysisTab.vue';
+  import { AnalysisTabs } from './util';
   
   export default defineComponent({
     props: {

--- a/web/shapeworks/src/components/Analysis/util.ts
+++ b/web/shapeworks/src/components/Analysis/util.ts
@@ -1,0 +1,5 @@
+export enum AnalysisTabs {
+    PCA = 0,
+    Groups,
+    Charts
+}


### PR DESCRIPTION
The analysis tabs enum was registering as unused, so I moved it into a separate `util.ts` file inside Analysis.