### PR TITLE
Project search/Select refactor

### DIFF
--- a/shapeworks_cloud/core/filters.py
+++ b/shapeworks_cloud/core/filters.py
@@ -32,16 +32,15 @@ class ProjectFilter(FilterSet):
     search = CharFilter(method='multifield_search')
 
     def multifield_search(self, queryset, name, value):
-            return queryset.filter(
-                Q(name__icontains=value)
-                | Q(description__icontains=value)
-                | Q(keywords__icontains=value)
-            )
-
+        return queryset.filter(
+            Q(name__icontains=value)
+            | Q(description__icontains=value)
+            | Q(keywords__icontains=value)
+        )
 
     class Meta:
         model = models.Project
-        fields = ['search','dataset']
+        fields = ['search', 'dataset']
 
 
 class SegmentationFilter(FilterSet):

--- a/shapeworks_cloud/core/filters.py
+++ b/shapeworks_cloud/core/filters.py
@@ -29,10 +29,19 @@ class SubjectFilter(FilterSet):
 
 class ProjectFilter(FilterSet):
     dataset = ModelChoiceFilter(queryset=models.Dataset.objects.all())
+    search = CharFilter(method='multifield_search')
+
+    def multifield_search(self, queryset, name, value):
+            return queryset.filter(
+                Q(name__icontains=value)
+                | Q(description__icontains=value)
+                | Q(keywords__icontains=value)
+            )
+
 
     class Meta:
         model = models.Project
-        fields = ['dataset']
+        fields = ['search','dataset']
 
 
 class SegmentationFilter(FilterSet):

--- a/shapeworks_cloud/core/tasks.py
+++ b/shapeworks_cloud/core/tasks.py
@@ -112,6 +112,7 @@ def run_shapeworks_command(
                 command,
                 f'--name={project_filename}',
             ]
+
             if command == 'analyze':
                 full_command.append('--output=analysis.json')
             else:

--- a/web/shapeworks/src/api/rest.ts
+++ b/web/shapeworks/src/api/rest.ts
@@ -46,8 +46,21 @@ export async function getSubjectsForDataset(datasetId: number): Promise<Subject[
     })).data.results
 }
 
-export async function getProjectsForDataset(datasetId: number): Promise<Project[]>{
-    return (await apiClient.get(`/projects?dataset=${datasetId}`)).data?.results
+export async function getProjectsForDataset(search: string | undefined, datasetId: number): Promise<Project[]>{
+    const results = []
+    let page = 1
+    let response = (await apiClient.get(`/projects`, {
+        params: { page, search, dataset: datasetId }
+    })).data
+    results.push(...response.results)
+    while(response.next){
+        page += 1
+        response = (await apiClient.get(`/projects`, {
+            params: { page, search, dataset: datasetId }
+        })).data
+        results.push(...response.results)
+    }
+    return results
 }
 
 export async function refreshProject(projectId: number){

--- a/web/shapeworks/src/components/FilterSearch.vue
+++ b/web/shapeworks/src/components/FilterSearch.vue
@@ -1,10 +1,7 @@
 <script lang="ts">
-import { defineComponent, ref } from '@vue/composition-api'
+import { defineComponent, onBeforeUpdate, ref, watch } from '@vue/composition-api'
 import router from '@/router';
-import { getDatasets } from '@/api/rest';
-import { loadingState, allDatasets, allProjectsForDataset, selectedDataset, selectedProject, loadProjectsForDataset } from '@/store';
-import { getProjectsForDataset } from '@/api/rest';
-
+import { selectedDataset, selectedProject } from '@/store';
 
 export default defineComponent({
     setup() {
@@ -12,29 +9,21 @@ export default defineComponent({
 
       async function navigateToResults() {
         // use store functions
-        loadingState.value = true;
-        
+        let targetUrl = "/"
         if (selectedDataset.value) {
-            // allProjectsForDataset.value = (await getProjectsForDataset(searchText.value, selectedDataset.value.id)).sort((a, b) => {
-            //     if(a.created < b.created) return 1;
-            //     if(a.created > b.created) return -1;
-            //     return 0;
-            // });
-            router.replace(`dataset/${selectedDataset.value.id}/search/${searchText.value}`)
-            loadProjectsForDataset(selectedDataset.value.id);
-        } else {
-            router.replace('/search/'+searchText.value)
-            allDatasets.value = (await getDatasets(searchText.value)).sort((a, b) => {
-                if(a.created < b.created) return 1;
-                if(a.created > b.created) return -1;
-                return 0;
-            });
+            targetUrl = `/dataset/${selectedDataset.value.id}/`
         }
-        loadingState.value = false;
+
+        if (searchText.value) {
+            targetUrl = targetUrl + `search/${searchText.value}`
+        }
+
+        router.push(targetUrl);
       }
 
       router.beforeEach(async (to, from, next) => {
         if (!to.params.searchText) searchText.value = ''
+        searchText.value = to.params.searchText;
         next()
       })
 
@@ -44,7 +33,7 @@ export default defineComponent({
         selectedProject,
         navigateToResults
       }
-    }
+    },
 })
 </script>
 
@@ -71,7 +60,7 @@ export default defineComponent({
                             </v-icon>
                         </span>
                     </template>
-                    <span>Search ShapeWorks datasets by name, description, and keywords</span>
+                    <span>Search ShapeWorks {{(selectedDataset) ? "projects" : "datasets"}} by name, description, and keywords</span>
                 </v-tooltip>
             </template>
         </v-text-field>

--- a/web/shapeworks/src/components/FilterSearch.vue
+++ b/web/shapeworks/src/components/FilterSearch.vue
@@ -2,7 +2,8 @@
 import { defineComponent, ref } from '@vue/composition-api'
 import router from '@/router';
 import { getDatasets } from '@/api/rest';
-import { loadingState, allDatasets, selectedDataset, selectedProject } from '@/store';
+import { loadingState, allDatasets, allProjectsForDataset, selectedDataset, selectedProject, loadProjectsForDataset } from '@/store';
+import { getProjectsForDataset } from '@/api/rest';
 
 
 export default defineComponent({
@@ -10,15 +11,25 @@ export default defineComponent({
       const searchText = ref(router.currentRoute.params.searchText)
 
       async function navigateToResults() {
-        router.replace('/search/'+searchText.value)
+        // use store functions
         loadingState.value = true;
-        selectedDataset.value = undefined;
-        selectedProject.value = undefined
-        allDatasets.value = (await getDatasets(searchText.value)).sort((a, b) => {
-            if(a.created < b.created) return 1;
-            if(a.created > b.created) return -1;
-            return 0;
-        });
+        
+        if (selectedDataset.value) {
+            // allProjectsForDataset.value = (await getProjectsForDataset(searchText.value, selectedDataset.value.id)).sort((a, b) => {
+            //     if(a.created < b.created) return 1;
+            //     if(a.created > b.created) return -1;
+            //     return 0;
+            // });
+            router.replace(`dataset/${selectedDataset.value.id}/search/${searchText.value}`)
+            loadProjectsForDataset(selectedDataset.value.id);
+        } else {
+            router.replace('/search/'+searchText.value)
+            allDatasets.value = (await getDatasets(searchText.value)).sort((a, b) => {
+                if(a.created < b.created) return 1;
+                if(a.created > b.created) return -1;
+                return 0;
+            });
+        }
         loadingState.value = false;
       }
 
@@ -29,6 +40,8 @@ export default defineComponent({
 
       return {
         searchText,
+        selectedDataset,
+        selectedProject,
         navigateToResults
       }
     }

--- a/web/shapeworks/src/components/FilterSearch.vue
+++ b/web/shapeworks/src/components/FilterSearch.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { defineComponent, onBeforeUpdate, ref, watch } from '@vue/composition-api'
+import { defineComponent, ref } from '@vue/composition-api'
 import router from '@/router';
 import { selectedDataset, selectedProject } from '@/store';
 

--- a/web/shapeworks/src/components/NavBar.vue
+++ b/web/shapeworks/src/components/NavBar.vue
@@ -14,6 +14,7 @@ export default defineComponent({
     setup() {
       const params = computed(() => ({
         dataset: selectedDataset.value?.id,
+        project: selectedProject.value?.id
       }))
 
       async function logInOrOut() {
@@ -47,6 +48,7 @@ export default defineComponent({
           selectedDataset,
           selectedProject,
           navigateToHome,
+          router,
       }
     }
 })
@@ -64,7 +66,7 @@ export default defineComponent({
       <v-toolbar-title class="text-h6">ShapeWorks</v-toolbar-title>
     </div>
     <v-spacer />
-    <filter-search v-if="!(selectedDataset && selectedProject)"/>
+    <filter-search v-if="!(selectedDataset && selectedProject) && !(router.currentRoute.params.dataset && router.currentRoute.params.project)"/>
     <v-spacer />
     <v-btn
       v-if="oauthClient.isLoggedIn"

--- a/web/shapeworks/src/components/NavBar.vue
+++ b/web/shapeworks/src/components/NavBar.vue
@@ -28,7 +28,9 @@ export default defineComponent({
       async function navigateToHome() {
         selectedDataset.value = undefined
         selectedProject.value = undefined
-        router.push('/')
+        if (router.currentRoute.path !== '/') {
+          router.push('/')
+        }
         loadingState.value = true;
         allDatasets.value = (await getDatasets(undefined)).sort((a, b) => {
             if(a.created < b.created) return 1;

--- a/web/shapeworks/src/components/NavBar.vue
+++ b/web/shapeworks/src/components/NavBar.vue
@@ -2,14 +2,14 @@
 import { defineComponent, computed } from '@vue/composition-api'
 import { logout, oauthClient } from '@/api/auth';
 import { allDatasets, loadingState, selectedDataset, selectedProject } from '@/store';
-import DatasetSearch from './DatasetSearch.vue';
+import FilterSearch from './FilterSearch.vue';
 import router from '@/router';
 import { getDatasets } from '@/api/rest';
 
 
 export default defineComponent({
     components: {
-      DatasetSearch
+      FilterSearch
     },
     setup() {
       const params = computed(() => ({
@@ -43,6 +43,7 @@ export default defineComponent({
           params,
           logInOrOut,
           selectedDataset,
+          selectedProject,
           navigateToHome,
       }
     }
@@ -61,7 +62,7 @@ export default defineComponent({
       <v-toolbar-title class="text-h6">ShapeWorks</v-toolbar-title>
     </div>
     <v-spacer />
-    <dataset-search />
+    <filter-search v-if="!(selectedDataset && selectedProject)"/>
     <v-spacer />
     <v-btn
       v-if="oauthClient.isLoggedIn"

--- a/web/shapeworks/src/components/ProjectForm.vue
+++ b/web/shapeworks/src/components/ProjectForm.vue
@@ -1,10 +1,9 @@
 <script>
 import { defineComponent, ref } from '@vue/composition-api';
-import { createProject, getProjectsForDataset, editProject } from '../api/rest'
+import { createProject, editProject } from '../api/rest'
 import {
     selectedDataset,
     loadingState,
-    allProjectsForDataset,
     editingProject,
     loadProjectsForDataset,
 } from '@/store';

--- a/web/shapeworks/src/components/ProjectForm.vue
+++ b/web/shapeworks/src/components/ProjectForm.vue
@@ -5,7 +5,8 @@ import {
     selectedDataset,
     loadingState,
     allProjectsForDataset,
-    editingProject
+    editingProject,
+    loadProjectsForDataset,
 } from '@/store';
 
 export default defineComponent({
@@ -52,9 +53,9 @@ export default defineComponent({
 
         submitFunction().then(async (response) => {
             if(response.status === 201){
-                allProjectsForDataset.value = await getProjectsForDataset(selectedDataset.value.id);
+                loadProjectsForDataset(selectedDataset.value.id);
             } else if (response.status === 200) {
-                allProjectsForDataset.value = await getProjectsForDataset(selectedDataset.value.id);
+                loadProjectsForDataset(selectedDataset.value.id);
                 editingProject.value = undefined;
             }
 

--- a/web/shapeworks/src/router.ts
+++ b/web/shapeworks/src/router.ts
@@ -8,9 +8,10 @@ import DatasetSelect from './views/DatasetSelect.vue'
 Vue.use(VueRouter)
 
 const castDatasetAndSubjectProps = (route: Route) => ({
-  dataset: parseInt(route.params.dataset),
-  project: parseInt(route.params.project),
-});
+    dataset: (route.params.dataset) ? parseInt(route.params.dataset): undefined,
+    project: (route.params.project) ? parseInt(route.params.project): undefined,
+    searchText: route.params.searchText,
+  });
 
 const routes: Array<RouteConfig> = [
   {
@@ -20,23 +21,27 @@ const routes: Array<RouteConfig> = [
     component: Main
   },
   {
-    path: 'dataset/:dataset/search/:searchText',
-    name: 'search',
+    path: '/dataset/:dataset/search/:searchText',
+    name: 'project-search',
+    props: castDatasetAndSubjectProps,
     component: ProjectSelect,
   },
   {
     path: '/search/:searchText',
-    name: 'search',
+    name: 'dataset-search',
+    props: castDatasetAndSubjectProps,
     component: DatasetSelect,
   },
   {
     path: '/dataset/:dataset',
-    name: 'main',
+    name: 'project-select',
+    props: castDatasetAndSubjectProps,
     component: ProjectSelect
   },
   {
     path: '/',
-    name: 'select',
+    name: 'dataset-select',
+    props: castDatasetAndSubjectProps,
     component: DatasetSelect,
   },
   {

--- a/web/shapeworks/src/router.ts
+++ b/web/shapeworks/src/router.ts
@@ -1,7 +1,9 @@
 import Vue from 'vue'
 import VueRouter, { Route, RouteConfig } from 'vue-router'
-import Select from './views/Select.vue'
 import Main from './views/Main.vue'
+import ProjectSelect from './views/ProjectSelect.vue'
+import DatasetSelect from './views/DatasetSelect.vue'
+
 
 Vue.use(VueRouter)
 
@@ -18,14 +20,24 @@ const routes: Array<RouteConfig> = [
     component: Main
   },
   {
+    path: 'dataset/:dataset/search/:searchText',
+    name: 'search',
+    component: ProjectSelect,
+  },
+  {
     path: '/search/:searchText',
     name: 'search',
-    component: Select,
+    component: DatasetSelect,
+  },
+  {
+    path: '/dataset/:dataset',
+    name: 'main',
+    component: ProjectSelect
   },
   {
     path: '/',
     name: 'select',
-    component: Select,
+    component: DatasetSelect,
   },
   {
     path: '*',

--- a/web/shapeworks/src/store/methods.ts
+++ b/web/shapeworks/src/store/methods.ts
@@ -57,6 +57,11 @@ export async function getAllDatasets() {
     loadingState.value = false;
 }
 
+export const loadProjectForDataset = async (projectId: number, datasetId: number) => {
+    await loadProjectsForDataset(datasetId);
+    selectProject(projectId);
+}
+
 export const loadProjectsForDataset = async (datasetId: number) => {
     const searchText = router.currentRoute.params.searchText;
     loadingState.value = true;

--- a/web/shapeworks/src/store/methods.ts
+++ b/web/shapeworks/src/store/methods.ts
@@ -65,9 +65,6 @@ export const loadProjectsForDataset = async (datasetId: number) => {
         if(a.created > b.created) return -1;
         return 0;
     });
-    if (!selectedProject.value) {
-        router.replace(`dataset/${datasetId}`);
-    }
     loadingState.value = false;
 }
 
@@ -76,13 +73,6 @@ export const selectProject = (projectId: number | undefined) => {
         selectedProject.value = allProjectsForDataset.value.find(
             (project: Project) => project.id == projectId,
         )
-        router.push({
-            name: 'main',
-            params: {
-                dataset: String(selectedDataset.value?.id),
-                project: String(projectId),
-            }
-        });
         layersShown.value = ["Original"]
     }
 }

--- a/web/shapeworks/src/store/methods.ts
+++ b/web/shapeworks/src/store/methods.ts
@@ -57,9 +57,8 @@ export async function getAllDatasets() {
     loadingState.value = false;
 }
 
-export const loadProjectForDataset = async (projectId: number, datasetId: number) => {
-    await loadProjectsForDataset(datasetId);
-    selectProject(projectId);
+export const loadProjectForDataset = async (projectId: number) => {
+    refreshProject(projectId).then((proj) => selectedProject.value = proj);
 }
 
 export const loadProjectsForDataset = async (datasetId: number) => {

--- a/web/shapeworks/src/views/DatasetSelect.vue
+++ b/web/shapeworks/src/views/DatasetSelect.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { defineComponent, onMounted, ref } from '@vue/composition-api';
+import { defineComponent, onMounted, ref, watch } from '@vue/composition-api';
 import {
     allDatasets,
     selectedDataset,
@@ -11,16 +11,26 @@ import {
 import { Dataset } from '@/types';
 import ProjectForm from '@/components/ProjectForm.vue';
 import SubsetSelection from '@/components/SubsetSelection.vue';
+import router from '@/router';
 
 export default defineComponent({
   components: { ProjectForm, SubsetSelection },
-    setup() {
+  props: {
+    searchText: {
+        type: String,
+        required: false
+    }
+  },
+    setup(props) {
         const selectingSubsetOf = ref();
+        selectedDataset.value = undefined;
 
         async function selectOrDeselectDataset (dataset: Dataset | undefined) {
-            if(!selectedDataset.value && dataset){
+            if(!selectedDataset.value && dataset) {
                 selectedDataset.value = dataset;
                 loadProjectsForDataset(dataset.id);
+
+                router.push("/dataset/"+dataset.id);
             } else {
                 selectedDataset.value = undefined;
                 selectedDataObjects.value = [];
@@ -38,6 +48,11 @@ export default defineComponent({
                 )
             }
         })
+
+        watch(() => props, () => {
+            getAllDatasets();
+            selectedDataset.value = undefined;
+        }, {deep:true});
 
         return {
             allDatasets,

--- a/web/shapeworks/src/views/DatasetSelect.vue
+++ b/web/shapeworks/src/views/DatasetSelect.vue
@@ -1,0 +1,175 @@
+<script lang="ts">
+import { defineComponent, onMounted, ref } from '@vue/composition-api';
+import {
+    allDatasets,
+    selectedDataset,
+    loadingState,
+    selectedDataObjects,
+    loadProjectsForDataset,
+    getAllDatasets,
+} from '@/store';
+import { Dataset } from '@/types';
+import ProjectForm from '@/components/ProjectForm.vue';
+import SubsetSelection from '@/components/SubsetSelection.vue';
+
+export default defineComponent({
+  components: { ProjectForm, SubsetSelection },
+    setup() {
+        const selectingSubsetOf = ref();
+
+        async function selectOrDeselectDataset (dataset: Dataset | undefined) {
+            if(!selectedDataset.value && dataset){
+                selectedDataset.value = dataset;
+                loadProjectsForDataset(dataset.id);
+            } else {
+                selectedDataset.value = undefined;
+                selectedDataObjects.value = [];
+                await getAllDatasets();
+            }
+        }
+
+        onMounted(async () => {
+            await getAllDatasets();
+            if(selectedDataset.value){
+                const datasetId = selectedDataset.value.id;
+                // reset selectedDataset to maintain updates from latest fetch of all datasets
+                selectedDataset.value = allDatasets.value.find(
+                    (d) => d.id == datasetId
+                )
+            }
+        })
+
+        return {
+            allDatasets,
+            selectedDataset,
+            selectOrDeselectDataset,
+            selectingSubsetOf,
+            loadingState,
+        }
+    }
+})
+</script>
+
+<template>
+    <div>
+        <div
+            v-if="!selectedDataset"
+            class="flex-container pa-5"
+            :style="selectingSubsetOf ? 'width: calc(100% - 500px)' : ''"
+        >
+            <v-card v-if="allDatasets.length === 0 && !loadingState" width="100%">
+                <v-card-title>No datasets.</v-card-title>
+            </v-card>
+            <v-card
+                v-for="dataset in allDatasets"
+                :key="'dataset_'+dataset.id"
+                :class="dataset.thumbnail? 'selectable-card with-thumbnail': 'selectable-card'"
+                v-show="!selectedDataset || selectedDataset == dataset"
+                :width="selectedDataset == dataset ? '100%' :''"
+            >
+                <div class="text-overline mb-4">
+                    DATASET ({{ dataset.created ? dataset.created.split('T')[0] : 'No creation time' }})
+                    <span v-if="dataset.private" class="red--text">
+                        (PRIVATE)
+                    </span>
+                </div>
+                <div class="card-contents">
+                    <div>
+                        <v-list-item-title class="text-h5 mb-1">
+                            {{ dataset.name }}
+                        </v-list-item-title>
+                        <v-list-item-subtitle>
+                            {{ dataset.description }}
+                        </v-list-item-subtitle>
+                        <div class="text-overline">
+                            {{ dataset.summary }}
+                        </div>
+                        <v-list-item-subtitle v-if="dataset.keywords">
+                            <v-chip small v-for="keyword in dataset.keywords.split(',')" :key="keyword">
+                                <i>{{ keyword }}</i>
+                            </v-chip>
+                        </v-list-item-subtitle>
+                    </div>
+                    <div v-if="dataset.thumbnail">
+                        <v-img :src="dataset.thumbnail" width="100"/>
+                    </div>
+                </div>
+
+                <v-card-actions class="action-buttons">
+                <v-btn
+                    outlined
+                    rounded
+                    text
+                    @click="() => selectOrDeselectDataset(dataset)"
+                >
+                    {{ selectedDataset ?'Deselect' :'Select' }}
+                </v-btn>
+                <v-btn
+                    outlined
+                    rounded
+                    text
+                    @click="() => selectingSubsetOf = dataset"
+                >
+                    Create subset
+                </v-btn>
+                </v-card-actions>
+            </v-card>
+        </div>
+        <v-navigation-drawer
+            right
+            absolute
+            width="500px"
+            :value="selectingSubsetOf !== undefined && !selectedDataset"
+        >
+             <v-btn
+                icon
+                @click.stop="selectingSubsetOf = undefined"
+                class="pa-3 pt-8"
+            >
+                <v-icon>mdi-close</v-icon>
+            </v-btn>
+            <subset-selection
+                :targetDataset="selectingSubsetOf"
+                v-if="selectingSubsetOf"
+                @close="selectingSubsetOf = undefined"
+            />
+        </v-navigation-drawer>
+    </div>
+</template>
+
+<style>
+.flex-container {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: stretch;
+    column-gap: 15px;
+    row-gap: 15px;
+    overflow: auto;
+}
+.selectable-card{
+    width: 275px;
+    padding: 10px 20px 70px 20px;
+}
+.card-contents {
+    display: flex;
+    justify-content: space-between;
+}
+.card-contents {
+    overflow-wrap: anywhere;
+}
+.selectable-card.with-thumbnail {
+    width: 375px;
+}
+.action-buttons {
+    position: absolute;
+    bottom: 10px;
+    left: 5px;
+    width: calc(100% - 10px);
+    display: flex;
+    justify-content: space-between;
+    margin-top: 10px;
+}
+.v-list-item__title, .v-list-item__subtitle {
+    white-space: normal!important;
+}
+</style>

--- a/web/shapeworks/src/views/Main.vue
+++ b/web/shapeworks/src/views/Main.vue
@@ -22,7 +22,7 @@ import {
     layersShown,
     groomedShapesForOriginalDataObjects,
     selectedProject,
-    loadProjectForDataset,
+    loadProjectsForDataset,
     reconstructionsForOriginalDataObjects,
     analysisFileShown,
     meanAnalysisFileParticles,
@@ -30,7 +30,8 @@ import {
     switchTab,
     landmarkColorList,
     jobAlreadyDone,
-    analysisExpandedTab
+    analysisExpandedTab,
+    selectProject
 } from '@/store';
 import router from '@/router';
 import TabForm from '@/components/TabForm.vue';
@@ -80,10 +81,11 @@ export default defineComponent({
         onMounted(async () => {
             try {
                 await loadDataset(props.dataset);
-                await loadProjectForDataset(props.project, props.dataset);
+                await loadProjectsForDataset(props.dataset);
             } catch(e) {
+                console.log(e);
                 router.push({
-                    name: 'select'
+                    name: 'project-select'
                 })
             }
             nextTick(() => {
@@ -103,7 +105,7 @@ export default defineComponent({
             selectedProject.value = undefined;
             analysisFileShown.value = undefined;
             router.push({
-                name: 'select',
+                name: 'dataset-select',
             });
         }
 

--- a/web/shapeworks/src/views/Main.vue
+++ b/web/shapeworks/src/views/Main.vue
@@ -31,7 +31,6 @@ import {
     landmarkColorList,
     jobAlreadyDone,
     analysisExpandedTab,
-    selectProject
 } from '@/store';
 import router from '@/router';
 import TabForm from '@/components/TabForm.vue';
@@ -84,9 +83,7 @@ export default defineComponent({
                 await loadProjectsForDataset(props.dataset);
             } catch(e) {
                 console.log(e);
-                router.push({
-                    name: 'project-select'
-                })
+                toSelectPage();
             }
             nextTick(() => {
                 window.addEventListener('resize', onResize);
@@ -104,9 +101,7 @@ export default defineComponent({
         async function toSelectPage() {
             selectedProject.value = undefined;
             analysisFileShown.value = undefined;
-            router.push({
-                name: 'dataset-select',
-            });
+            router.push('/dataset/'+selectedDataset.value?.id);
         }
 
         function prepareDrawer() {

--- a/web/shapeworks/src/views/Main.vue
+++ b/web/shapeworks/src/views/Main.vue
@@ -22,7 +22,7 @@ import {
     layersShown,
     groomedShapesForOriginalDataObjects,
     selectedProject,
-    loadProjectsForDataset,
+    loadProjectForDataset,
     reconstructionsForOriginalDataObjects,
     analysisFileShown,
     meanAnalysisFileParticles,
@@ -80,7 +80,7 @@ export default defineComponent({
         onMounted(async () => {
             try {
                 await loadDataset(props.dataset);
-                await loadProjectsForDataset(props.dataset);
+                await loadProjectForDataset(props.project, props.dataset);
             } catch(e) {
                 console.log(e);
                 toSelectPage();

--- a/web/shapeworks/src/views/Main.vue
+++ b/web/shapeworks/src/views/Main.vue
@@ -31,6 +31,8 @@ import {
     landmarkColorList,
     jobAlreadyDone,
     analysisExpandedTab,
+allProjectsForDataset,
+loadProjectsForDataset,
 } from '@/store';
 import router from '@/router';
 import TabForm from '@/components/TabForm.vue';
@@ -80,7 +82,7 @@ export default defineComponent({
         onMounted(async () => {
             try {
                 await loadDataset(props.dataset);
-                await loadProjectForDataset(props.project, props.dataset);
+                await loadProjectForDataset(props.project);
             } catch(e) {
                 console.log(e);
                 toSelectPage();
@@ -101,6 +103,9 @@ export default defineComponent({
         async function toSelectPage() {
             selectedProject.value = undefined;
             analysisFileShown.value = undefined;
+            if (allProjectsForDataset.value.length === 0 && selectedDataset.value) {
+                loadProjectsForDataset(selectedDataset.value.id);
+            }
             router.push('/dataset/'+selectedDataset.value?.id);
         }
 

--- a/web/shapeworks/src/views/ProjectSelect.vue
+++ b/web/shapeworks/src/views/ProjectSelect.vue
@@ -1,105 +1,56 @@
 <script lang="ts">
-import { defineComponent, onMounted, ref } from '@vue/composition-api';
-import { getDatasets, getProjectsForDataset, deleteProject } from '@/api/rest'
+import { defineComponent, ref } from '@vue/composition-api';
+import { deleteProject } from '@/api/rest'
 import {
-    allDatasets,
     selectedDataset,
     loadingState,
-    selectedDataObjects,
     allProjectsForDataset,
-    loadProjectForDataset,
     selectedProject,
     editingProject,
+    selectProject,
+selectedDataObjects,
+getAllDatasets,
 } from '@/store';
-import { Dataset, Project } from '@/types';
-import router from '@/router';
 import ProjectForm from '@/components/ProjectForm.vue';
 import SubsetSelection from '@/components/SubsetSelection.vue';
+import { Project } from '@/types';
 
 export default defineComponent({
   components: { ProjectForm, SubsetSelection },
     setup() {
         const deleting = ref();
-        const selectingSubsetOf = ref();
-
-        async function getAllDatasets() {
-            const searchText = router.currentRoute.params.searchText
-            loadingState.value = true;
-            allDatasets.value = (await getDatasets(searchText)).sort((a, b) => {
-                if(a.created < b.created) return 1;
-                if(a.created > b.created) return -1;
-                return 0;
-            });
-            loadingState.value = false;
-        }
-
-        async function fetchProjectsForDataset(dataset: Dataset) {
-            allProjectsForDataset.value = await getProjectsForDataset(dataset.id);
-        }
-
-        async function selectOrDeselectDataset (dataset: Dataset | undefined) {
-            if(!selectedDataset.value && dataset){
-                selectedDataset.value = dataset;
-                fetchProjectsForDataset(dataset)
-            } else {
-                selectedDataset.value = undefined;
-                selectedDataObjects.value = [];
-                await getAllDatasets();
-            }
-        }
 
         async function selectOrDeselectProject (project: Project) {
             if(!selectedProject.value){
-                selectedProject.value = project;
-                router.push({
-                    name: 'main',
-                    params: {
-                        dataset: String(selectedDataset.value?.id),
-                        project: String(project.id),
-                    }
-                });
+                selectProject(project.id);
             } else {selectedProject.value = undefined;
                 selectedDataObjects.value = [];
                 await getAllDatasets();
             }
         }
-
+        
         function deleteProj() {
             loadingState.value = true
             deleteProject(deleting.value.id).then(
                 () => {
                     deleting.value = undefined
                     if(selectedDataset.value){
-                        loadProjectForDataset(undefined, selectedDataset.value.id)
+                        selectedProject.value = undefined;
                     }
                     loadingState.value = false
                 }
             )
         }
 
-        onMounted(async () => {
-            await getAllDatasets();
-            if(selectedDataset.value){
-                const datasetId = selectedDataset.value.id;
-                // reset selectedDataset to maintain updates from latest fetch of all datasets
-                selectedDataset.value = allDatasets.value.find(
-                    (d) => d.id == datasetId
-                )
-            }
-        })
-
         return {
-            allDatasets,
             selectedDataset,
             allProjectsForDataset,
             selectedProject,
-            selectOrDeselectDataset,
             selectOrDeselectProject,
             deleting,
             deleteProj,
             editingProject,
-            selectingSubsetOf,
-            loadingState,
+            selectProject
         }
     }
 })
@@ -107,72 +58,9 @@ export default defineComponent({
 
 <template>
     <div>
-        <div
-            v-if="!selectedDataset"
-            class="flex-container pa-5"
-            :style="selectingSubsetOf ? 'width: calc(100% - 500px)' : ''"
-        >
-            <v-card v-if="allDatasets.length === 0 && !loadingState" width="100%">
-                <v-card-title>No datasets.</v-card-title>
-            </v-card>
-            <v-card
-                v-for="dataset in allDatasets"
-                :key="'dataset_'+dataset.id"
-                :class="dataset.thumbnail? 'selectable-card with-thumbnail': 'selectable-card'"
-                v-show="!selectedDataset || selectedDataset == dataset"
-                :width="selectedDataset == dataset ? '100%' :''"
-            >
-                <div class="text-overline mb-4">
-                    DATASET ({{ dataset.created ? dataset.created.split('T')[0] : 'No creation time' }})
-                    <span v-if="dataset.private" class="red--text">
-                        (PRIVATE)
-                    </span>
-                </div>
-                <div class="card-contents">
-                    <div>
-                        <v-list-item-title class="text-h5 mb-1">
-                            {{ dataset.name }}
-                        </v-list-item-title>
-                        <v-list-item-subtitle>
-                            {{ dataset.description }}
-                        </v-list-item-subtitle>
-                        <div class="text-overline">
-                            {{ dataset.summary }}
-                        </div>
-                        <v-list-item-subtitle v-if="dataset.keywords">
-                            <v-chip small v-for="keyword in dataset.keywords.split(',')" :key="keyword">
-                                <i>{{ keyword }}</i>
-                            </v-chip>
-                        </v-list-item-subtitle>
-                    </div>
-                    <div v-if="dataset.thumbnail">
-                        <v-img :src="dataset.thumbnail" width="100"/>
-                    </div>
-                </div>
-
-                <v-card-actions class="action-buttons">
-                <v-btn
-                    outlined
-                    rounded
-                    text
-                    @click="() => selectOrDeselectDataset(dataset)"
-                >
-                    {{ selectedDataset ?'Deselect' :'Select' }}
-                </v-btn>
-                <v-btn
-                    outlined
-                    rounded
-                    text
-                    @click="() => selectingSubsetOf = dataset"
-                >
-                    Create subset
-                </v-btn>
-                </v-card-actions>
-            </v-card>
-        </div>
-        <div v-else class="flex-container pa-5">
+        <div v-if="selectedDataset" class="flex-container pa-5">
             <div style="width:100%">
-                <v-icon @click="() => selectOrDeselectDataset(selectedDataset)">
+                <v-icon @click="() => selectedDataset = undefined">
                     mdi-arrow-left
                 </v-icon>
                 {{ selectedDataset.name }}
@@ -223,7 +111,7 @@ export default defineComponent({
                         text
                         @click="() => selectOrDeselectProject(project)"
                     >
-                        {{ selectedProject ?'Deselect' :'Select' }}
+                        Select
                     </v-btn>
                     <v-btn
                         outlined
@@ -280,25 +168,6 @@ export default defineComponent({
             </v-card>
             </v-dialog>
         </div>
-        <v-navigation-drawer
-            right
-            absolute
-            width="500px"
-            :value="selectingSubsetOf !== undefined && !selectedDataset"
-        >
-             <v-btn
-                icon
-                @click.stop="selectingSubsetOf = undefined"
-                class="pa-3 pt-8"
-            >
-                <v-icon>mdi-close</v-icon>
-            </v-btn>
-            <subset-selection
-                :targetDataset="selectingSubsetOf"
-                v-if="selectingSubsetOf"
-                @close="selectingSubsetOf = undefined"
-            />
-        </v-navigation-drawer>
     </div>
 </template>
 


### PR DESCRIPTION
Closes #317 

This PR includes:

Router changes:
- Selecting a dataset changes the url to point to `/dataset/{dataset_id}`
- Type cast props are passed to all routes now instead of just project route
- Added route for project search (`/dataset/{id}/project/{id}/search/{searchtext}`)
- These routes can all be navigated to via url
- Fixed redundant home navigation when clicking home button

Select changes:
- Separated `Select.vue` into two subcomponents, `DatasetSelect` and `ProjectSelect` which handle their respective logic
- `ProjectSelect` is referenced by project searching or after selecting a dataset
- `DatasetSelect` is referenced by dataset searching or when on the dataset screen

Search changes:
- Added project searching via `.../project/{id}/search/{searchText}/`
- Fixed issue with dataset searching where changing the search text in the URL would not update the search
- Removed the search bar from the navbar while working inside a project

Misc:
- Added `getProjectsForDataset` to rest api
- Reworked some `methods.ts` functions to be more consistent and intuitive