### PR TITLE
Grooming landmark alignment option

### DIFF
--- a/web/shapeworks/public/forms/groom_mesh.json
+++ b/web/shapeworks/public/forms/groom_mesh.json
@@ -159,7 +159,8 @@
                     "x-cols": 6,
                     "enum": [
                         "Center",
-                        "Iterative Closest Point"
+                        "Iterative Closest Point",
+                        "Landmark"
                     ],
                     "x-class": "float-right pl-5",
                     "x-display": "custom-conditional",

--- a/web/shapeworks/public/forms/groom_segmentation.json
+++ b/web/shapeworks/public/forms/groom_segmentation.json
@@ -302,7 +302,8 @@
                     "x-cols": 6,
                     "enum": [
                         "Center",
-                        "Iterative Closest Point"
+                        "Iterative Closest Point",
+                        "Landmark"
                     ],
                     "x-class": "float-right pl-5",
                     "x-display": "custom-conditional",


### PR DESCRIPTION
Transforms confirm that landmark alignment is working. The actual groomed mesh doesn't change.

@annehaley the studio changes were because the "align" option was checked in the shapeviewer.