### PR TITLE
margin-left adjustment for first button in group

### DIFF
--- a/web/shapeworks/src/views/ProjectSelect.vue
+++ b/web/shapeworks/src/views/ProjectSelect.vue
@@ -157,7 +157,7 @@ export default defineComponent({
                     </div>
                     <v-card-actions class="action-buttons">
                         <v-btn
-                            outlined rounded text style="width:40%"
+                            outlined rounded text style="width:40%; margin-left: 8px;"
                             @click="() => cloneProj(project)"
                         >
                             Clone


### PR DESCRIPTION
Before:
![image](https://github.com/girder/shapeworks-cloud/assets/35744963/5dac8bf5-e303-4acd-abd1-9cfeee149acf)

After:
![image](https://github.com/girder/shapeworks-cloud/assets/35744963/23fe5d47-81e3-4a17-94c4-c5934615f4ee)


MUI doesn't apply the left margin for a button group's first member since they are typically in one line. This means the clone button didn't have the proper margin applied.