### PR TITLE
Add middleware setting

### DIFF
--- a/shapeworks_cloud/settings.py
+++ b/shapeworks_cloud/settings.py
@@ -38,6 +38,8 @@ class ShapeworksCloudMixin(ConfigMixin):
             's3_file_field',
         ]
 
+        configuration.MIDDLEWARE += ['allauth.account.middleware.AccountMiddleware']
+
         configuration.REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'] += [
             'rest_framework.authentication.TokenAuthentication',
         ]


### PR DESCRIPTION
This is a patch to fix the following error: 
```
raise ImproperlyConfigured(
django.core.exceptions.ImproperlyConfigured: allauth.account.middleware.AccountMiddleware must be added to settings.MIDDLEWARE
```

This should be fixed upstream some time soon, and at that point, we should remove this patch.