### PR TITLE
Version pins

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
         'dev': [
             'django-composed-configuration[dev]',
             'django-debug-toolbar',
-            'django-s3-file-field[minio]',
+            'django-s3-file-field[minio]<1',
             'ipython',
             'openpyxl',
             'tox',

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ skip_install = false
 usedevelop = true
 deps =
     mypy<0.920
-    django-stubs
+    django-stubs<2
     djangorestframework-stubs
 commands =
     mypy {posargs} setup.py shapeworks_cloud


### PR DESCRIPTION
With `django-stubs>2`, we get the following error:
> setup.cfg:15: error: Error importing plugin "mypy_django_plugin.main": cannot import name 'has_placeholder' from 'mypy.semanal_shared' (/home/runner/work/shapeworks-cloud/shapeworks-cloud/.tox/type/lib/python3.8/site-packages/mypy/semanal_shared.cpython-38-x86_64-linux-gnu.so)