### PR TITLE
Update typing for server and swcc

### DIFF
--- a/shapeworks_cloud/core/admin.py
+++ b/shapeworks_cloud/core/admin.py
@@ -8,6 +8,6 @@ from . import models as models
 for key in dir(models):
     if key != 'User':
         prop = getattr(models, key, None)
-        if hasattr(prop, '_meta') and not getattr(prop._meta, 'abstract', None):
+        if prop and hasattr(prop, '_meta') and not getattr(prop._meta, 'abstract', None):
             if inspect.isclass(prop) and issubclass(prop, django.db.models.Model):
                 admin.site.register(getattr(models, key))

--- a/shapeworks_cloud/core/management/commands/makeclient.py
+++ b/shapeworks_cloud/core/management/commands/makeclient.py
@@ -16,7 +16,7 @@ class Command(BaseCommand):
         if not uri:
             uri = DEFAULT_REDIRECT_URI
 
-        site = Site.objects.get_current()
+        site = Site.objects.get_current()  # type: ignore
         site.domain = 'app.shapeworks-cloud.org'
         site.name = 'ShapeWorks Cloud'
         site.save()

--- a/shapeworks_cloud/core/migrations/0001_initial.py
+++ b/shapeworks_cloud/core/migrations/0001_initial.py
@@ -9,7 +9,7 @@ import s3_file_field.fields
 class Migration(migrations.Migration):
     initial = True
 
-    dependencies = []  # type: ignore
+    dependencies = []
 
     operations = [
         migrations.CreateModel(

--- a/shapeworks_cloud/core/rest.py
+++ b/shapeworks_cloud/core/rest.py
@@ -266,8 +266,8 @@ class ProjectViewSet(BaseViewSet):
         # project has new id now, is the cloned object
         for related_model in related_models:
             for related_object in related_model.objects.filter(project=project):
-                related_object.id = None
-                related_object.project = project
+                related_object.id = None  # type: ignore
+                related_object.project = project  # type: ignore
                 related_object.save()
         return Response(
             serializers.ProjectReadSerializer(project).data, status=status.HTTP_201_CREATED

--- a/shapeworks_cloud/core/tasks.py
+++ b/shapeworks_cloud/core/tasks.py
@@ -83,7 +83,7 @@ def run_shapeworks_command(
     user = User.objects.get(id=user_id)
     progress = models.TaskProgress.objects.get(id=progress_id)
     token, _created = Token.objects.get_or_create(user=user)
-    base_url = settings.API_URL
+    base_url = settings.API_URL  # type: ignore
 
     with TemporaryDirectory() as download_dir:
         with swcc_session(base_url=base_url) as session:

--- a/shapeworks_cloud/urls.py
+++ b/shapeworks_cloud/urls.py
@@ -69,7 +69,7 @@ urlpatterns = [
     path('api/docs/redoc/', schema_view.with_ui('redoc'), name='docs-redoc'),
     path('api/docs/swagger/', schema_view.with_ui('swagger'), name='docs-swagger'),
     path('api-token-auth/', obtain_auth_token),
-    path('', RedirectView.as_view(url=settings.HOMEPAGE_REDIRECT_URL)),
+    path('', RedirectView.as_view(url=settings.HOMEPAGE_REDIRECT_URL)),  # type: ignore
 ]
 
 if settings.DEBUG:

--- a/swcc/examples/upload_examples.py
+++ b/swcc/examples/upload_examples.py
@@ -22,7 +22,7 @@ with swcc_session(base_url='http://localhost:8000/api/v1') as session:
 
     project_file_1 = Path('left_atrium/left_atrium.swproj')
     project_1 = Project(
-        file=project_file_1,
+        file_source=project_file_1,
         description='First project for left atrium data',
         dataset=dataset_1,
         last_cached_analysis='analysis/left_atrium_analysis.json',
@@ -39,7 +39,7 @@ with swcc_session(base_url='http://localhost:8000/api/v1') as session:
 
     project_file_2 = Path('ellipsoid/ellipsoid.swproj')
     project_2 = Project(
-        file=project_file_2,
+        file_source=project_file_2,
         description='First project for ellipsoid data',
         dataset=dataset_2,
     ).create()

--- a/swcc/swcc/cli.py
+++ b/swcc/swcc/cli.py
@@ -8,7 +8,7 @@ import traceback
 
 import click
 from packaging.version import parse as parse_version
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 import requests
 from requests.exceptions import RequestException
 

--- a/swcc/swcc/models/api_model.py
+++ b/swcc/swcc/models/api_model.py
@@ -1,36 +1,32 @@
+import inspect
 from pathlib import Path
+from typing import Any, Dict, Iterator, Optional, Type, TypeVar, Union
 
-try:
-    from typing import Any, Dict, Iterator, Optional, Type, TypeVar, Union
-except ImportError:
-    from typing import (
-        Any,
-        Dict,
-        Iterator,
-        Optional,
-        Type,
-        TypeVar,
-        Union,
-    )
-
-from pydantic.v1 import BaseModel, validator
-from pydantic.v1.fields import ModelField
+from pydantic.v1 import AnyHttpUrl, BaseModel, parse_obj_as, validator
 import requests
 
 from ..api import current_session
+from .file import File
 
 ModelType = TypeVar('ModelType', bound='ApiModel')
 
 
 class ApiModel(BaseModel):
     _endpoint: Optional[str] = None
+    _file_fields: Dict = {}
+    _files: Dict = {}
 
     id: Optional[int] = None
 
     @validator('*', pre=True)
-    def fetch_entity(cls, v, field: ModelField):
+    def fetch_entity(cls, v, field):
         type_ = cls.__fields__[field.name].type_
-        if type_ is not Any and issubclass(type_, ApiModel) and isinstance(v, int):
+        if (
+            inspect.isclass(type_)
+            and type_ is not Any
+            and issubclass(type_, ApiModel)
+            and isinstance(v, int)
+        ):
             return type_.from_id(v)
         return v
 
@@ -45,18 +41,8 @@ class ApiModel(BaseModel):
             r: requests.Response = session.get(f'{cls._endpoint}/{id}/')
             raise_for_status(r)
             json = r.json()
-            for key, value in cls.__fields__.items():
-                if key in kwargs:
-                    json[key] = kwargs[key]
-                elif (
-                    key in json
-                    and json[key]
-                    and value.type_ is not Any
-                    and issubclass(value.type_, ApiModel)
-                ):
-                    json[key] = value.type_.from_id(json[key])
-            cache[id] = cls(**json)
-        return cache[id]
+            cache[id] = json
+        return cls.from_json(cache[id])
 
     @classmethod
     def list(cls: Type[ModelType], **kwargs) -> Iterator[ModelType]:
@@ -80,33 +66,46 @@ class ApiModel(BaseModel):
             data = r.json()
             for result in data['results']:
                 result.update(replace)
-                yield cls(**result)
+                yield cls.from_json(result)
             if not data.get('next'):
                 return
 
             r = session.get(data['next'])
 
-    def delete(self) -> None:
-        from .utils import raise_for_status
+    @classmethod
+    def from_json(cls: Type[ModelType], original_json, **kwargs):
+        json = original_json.copy()
+        for key, value in cls.__fields__.items():
+            if key in kwargs:
+                json[key] = kwargs[key]
+            elif '_source' in key:
+                new_key = key.replace('_source', '')
+                json[key] = json[new_key]
+                del json[new_key]
+            elif (
+                key in json
+                and type(json[key]) == int
+                and inspect.isclass(value.type_)  # exclude Unions of multiple classes
+                and value.type_ is not Any
+                and issubclass(value.type_, ApiModel)
+            ):
+                json[key] = value.type_.from_id(json[key])
+        return cls(**json)
 
-        session = current_session()
-
-        self.assert_remote()
-        r: requests.Response = session.delete(f'{self._endpoint}/{self.id}/')
-        raise_for_status(r)
-        self.id = None
-
-    def create(self: ModelType) -> ModelType:
-        from .file import File
-        from .utils import raise_for_status
-
-        session = current_session()
-
-        self.assert_local()
+    def to_json(self):
         json = self.__dict__.copy()
         if 'file_io' in json:
             del json['file_io']
         for key, value in self:
+            if '_source' in key:
+                del json[key]
+                new_key = key.replace('_source', '')
+                file = getattr(self, new_key)
+                if file is not None:
+                    if file.field_value:
+                        json[new_key] = file.field_value
+                    else:
+                        json[new_key] = file.upload()
             if isinstance(value, File):
                 json[key] = value.upload()
             if isinstance(value, ApiModel):
@@ -121,20 +120,39 @@ class ApiModel(BaseModel):
                     else:
                         ids.append(item.id)
                 json[key] = ids
+        return json
 
+    def delete(self) -> None:
+        from .utils import raise_for_status
+
+        session = current_session()
+
+        self.assert_remote()
+        r: requests.Response = session.delete(f'{self._endpoint}/{self.id}/')
+        raise_for_status(r)
+        self.id = None
+
+    def create(self: ModelType) -> ModelType:
+        from .utils import raise_for_status
+
+        session = current_session()
+
+        self.assert_local()
+        json = self.to_json()
         r: requests.Response = session.post(f'{self._endpoint}/', json=json)
         raise_for_status(r)
-        self.id = r.json()['id']
+        json = r.json()
+        self.id = json['id']
+        for key, file in self._files.items():
+            if key in json:
+                file.url = parse_obj_as(AnyHttpUrl, json[key])
         if 'creator' in r.json():
             self.creator = r.json()['creator']
         return self
 
     def download_files(self, path: Union[Path, str]) -> Iterator[Path]:
-        from .file import File
-
-        for _, value in self:
-            if isinstance(value, File):
-                yield value.download(path)
+        for file in self._files.values():
+            yield file.download(path)
 
     def assert_remote(self):
         if self.id is None:
@@ -143,3 +161,14 @@ class ApiModel(BaseModel):
     def assert_local(self):
         if self.id is not None:
             raise Exception('This entity already exists on the server (id: %r).' % self.id)
+
+    def __getattribute__(self, name):
+        if name != '_file_fields':
+            if name in self._file_fields.keys():
+                source = object.__getattribute__(self, name + '_source')
+                if source is not None and name not in self._files:
+                    self._files[name] = File(source, field_id=self._file_fields[name])
+                return self._files.get(name)
+
+        # Default behaviour
+        return object.__getattribute__(self, name)

--- a/swcc/swcc/models/api_model.py
+++ b/swcc/swcc/models/api_model.py
@@ -97,7 +97,7 @@ class ApiModel(BaseModel):
         self.id = None
 
     def create(self: ModelType) -> ModelType:
-        from .file_type import FileType
+        from .file import File
         from .utils import raise_for_status
 
         session = current_session()
@@ -107,7 +107,7 @@ class ApiModel(BaseModel):
         if 'file_io' in json:
             del json['file_io']
         for key, value in self:
-            if isinstance(value, FileType):
+            if isinstance(value, File):
                 json[key] = value.upload()
             if isinstance(value, ApiModel):
                 if value.id is None:
@@ -130,10 +130,10 @@ class ApiModel(BaseModel):
         return self
 
     def download_files(self, path: Union[Path, str]) -> Iterator[Path]:
-        from .file_type import FileType
+        from .file import File
 
         for _, value in self:
-            if isinstance(value, FileType):
+            if isinstance(value, File):
                 yield value.download(path)
 
     def assert_remote(self):

--- a/swcc/swcc/models/api_model.py
+++ b/swcc/swcc/models/api_model.py
@@ -23,9 +23,9 @@ ModelType = TypeVar('ModelType', bound='ApiModel')
 
 
 class ApiModel(BaseModel):
-    _endpoint: str
+    _endpoint: Optional[str] = None
 
-    id: Optional[int]
+    id: Optional[int] = None
 
     @validator('*', pre=True)
     def fetch_entity(cls, v, field: ModelField):

--- a/swcc/swcc/models/api_model.py
+++ b/swcc/swcc/models/api_model.py
@@ -2,7 +2,7 @@ import inspect
 from pathlib import Path
 from typing import Any, Dict, Iterator, Optional, Type, TypeVar, Union
 
-from pydantic.v1 import AnyHttpUrl, BaseModel, parse_obj_as, validator
+from pydantic.v1 import AnyHttpUrl, BaseModel, PrivateAttr, parse_obj_as, validator
 import requests
 
 from ..api import current_session
@@ -14,7 +14,7 @@ ModelType = TypeVar('ModelType', bound='ApiModel')
 class ApiModel(BaseModel):
     _endpoint: Optional[str] = None
     _file_fields: Dict = {}
-    _files: Dict = {}
+    _files: Dict = PrivateAttr(default_factory=dict)
 
     id: Optional[int] = None
 
@@ -150,7 +150,7 @@ class ApiModel(BaseModel):
             self.creator = r.json()['creator']
         return self
 
-    def download_files(self, path: Union[Path, str]) -> Iterator[Path]:
+    def download_files(self, path: Union[str, Path]) -> Iterator[Path]:
         for file in self._files.values():
             yield file.download(path)
 

--- a/swcc/swcc/models/dataset.py
+++ b/swcc/swcc/models/dataset.py
@@ -1,18 +1,19 @@
 import re
 from typing import Iterator
+from pydantic.v1 import Field
 
 from .api_model import ApiModel
-from .utils import NonEmptyString, logger
+from .utils import logger
 
 
 class Dataset(ApiModel):
     _endpoint = 'datasets'
 
-    name: NonEmptyString
+    name: str = Field(min_length=3, max_length=255)
     private: bool = False
-    license: NonEmptyString
-    description: NonEmptyString
-    acknowledgement: NonEmptyString
+    license: str = Field(min_length=3)
+    description: str = Field(min_length=3)
+    acknowledgement: str = Field(min_length=3)
     creator: str = ''
     keywords: str = ''
     contributors: str = ''
@@ -98,10 +99,10 @@ class Dataset(ApiModel):
                     name, old_version = match.groups()
                     logger.info('Trying a new name: %s, %s', name, old_version)
                     new_version = int(old_version) + 1
-                    self.name = f'{name}-v{new_version}'  # type: ignore
+                    self.name = f'{name}-v{new_version}'
                 else:
                     # The old name had no suffix, so append "-v1"
-                    self.name = f'{self.name}-v1'  # type: ignore
+                    self.name = f'{self.name}-v1'
             # We have a new name now, but that new name might also conflict.
             # Keep looping until there is no conflict.
             old_dataset = Dataset.from_name(self.name)

--- a/swcc/swcc/models/dataset.py
+++ b/swcc/swcc/models/dataset.py
@@ -1,5 +1,6 @@
 import re
 from typing import Iterator
+
 from pydantic.v1 import Field
 
 from .api_model import ApiModel

--- a/swcc/swcc/models/file.py
+++ b/swcc/swcc/models/file.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Optional, Union
 from urllib.parse import unquote
 
-from pydantic.v1 import AnyHttpUrl, BaseModel, FilePath, ValidationError, parse_obj_as
+from pydantic.v1 import AnyHttpUrl, FilePath, ValidationError, parse_obj_as
 import requests
 
 from ..api import current_session
@@ -13,26 +13,26 @@ from ..api import current_session
 logger = logging.getLogger(__name__)
 
 
-class File(BaseModel):
-    def __init__(
-        self,
-        v: Optional[Union[Path, str]],
-        field_id: Optional[str] = None,
-    ):
+class File:
+    def __init__(self, v: Optional[Union[Path, str]], field_id: Optional[str] = None, **kwargs):
         self.field_id: Optional[str] = field_id
         self.path: Optional[Path] = None
         self.url: Optional[AnyHttpUrl] = None
         self.field_value: Optional[str] = None
 
-        try:
-            self.path = parse_obj_as(FilePath, v)
-        except ValidationError:
-            pass
+        if v is not None:
+            if isinstance(v, Path):
+                self.path = v
+            else:
+                try:
+                    self.path = parse_obj_as(FilePath, v)
+                except ValidationError:
+                    pass
 
-        try:
-            self.url = parse_obj_as(AnyHttpUrl, v)
-        except ValidationError:
-            pass
+                try:
+                    self.url = parse_obj_as(AnyHttpUrl, v)
+                except ValidationError:
+                    pass
 
         if self.path is None and self.url is None:
             raise ValueError('Could not parse File as a local path or a remote url')

--- a/swcc/swcc/models/file.py
+++ b/swcc/swcc/models/file.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 class File:
-    def __init__(self, v: Optional[Union[Path, str]], field_id: Optional[str] = None, **kwargs):
+    def __init__(self, v: Optional[Union[str, Path]], field_id: Optional[str] = None, **kwargs):
         self.field_id: Optional[str] = field_id
         self.path: Optional[Path] = None
         self.url: Optional[AnyHttpUrl] = None
@@ -59,7 +59,7 @@ class File:
 
         return self.field_value
 
-    def download(self, path: Union[Path, str]) -> Path:
+    def download(self, path: Union[str, Path]) -> Path:
         from .utils import raise_for_status
 
         if self.url is None:

--- a/swcc/swcc/models/other_models.py
+++ b/swcc/swcc/models/other_models.py
@@ -12,7 +12,7 @@ class Segmentation(ApiModel):
     _endpoint = 'segmentations'
     _file_fields = {'file': 'core.Segmentation.file'}
 
-    file_source: Union[Path, str]
+    file_source: Union[str, Path]
     anatomy_type: str = Field(min_length=1)
     subject: Subject
 
@@ -21,7 +21,7 @@ class Mesh(ApiModel):
     _endpoint = 'meshes'
     _file_fields = {'file': 'core.Mesh.file'}
 
-    file_source: Union[Path, str]
+    file_source: Union[str, Path]
     anatomy_type: str = Field(min_length=1)
     subject: Subject
 
@@ -30,7 +30,7 @@ class Contour(ApiModel):
     _endpoint = 'contours'
     _file_fields = {'file': 'core.Contour.file'}
 
-    file_source: Union[Path, str]
+    file_source: Union[str, Path]
     anatomy_type: str = Field(min_length=1)
     subject: Subject
 
@@ -39,7 +39,7 @@ class Image(ApiModel):
     _endpoint = 'images'
     _file_fields = {'file': 'core.Image.file'}
 
-    file_source: Union[Path, str]
+    file_source: Union[str, Path]
     modality: str
     subject: Subject
 
@@ -52,9 +52,9 @@ class GroomedSegmentation(ApiModel):
         'pre_alignment': 'core.GroomedSegmentation.pre_alignment',
     }
 
-    file_source: Union[Path, str]
-    pre_cropping_source: Optional[Union[Path, str]] = None
-    pre_alignment_source: Optional[Union[Path, str]] = None
+    file_source: Union[str, Path]
+    pre_cropping_source: Optional[Union[str, Path]] = None
+    pre_alignment_source: Optional[Union[str, Path]] = None
     segmentation: Segmentation
     project: Project
 
@@ -67,9 +67,9 @@ class GroomedMesh(ApiModel):
         'pre_alignment': 'core.GroomedMesh.pre_alignment',
     }
 
-    file_source: Union[Path, str]
-    pre_cropping_source: Optional[Union[Path, str]] = None
-    pre_alignment_source: Optional[Union[Path, str]] = None
+    file_source: Union[str, Path]
+    pre_cropping_source: Optional[Union[str, Path]] = None
+    pre_alignment_source: Optional[Union[str, Path]] = None
     mesh: Mesh
     project: Project
 
@@ -82,9 +82,9 @@ class OptimizedParticles(ApiModel):
         'transform': 'core.OptimizedParticles.transform',
     }
 
-    world_source: Optional[Union[Path, str]] = None
-    local_source: Optional[Union[Path, str]] = None
-    transform_source: Optional[Union[Path, str]] = None
+    world_source: Optional[Union[str, Path]] = None
+    local_source: Optional[Union[str, Path]] = None
+    transform_source: Optional[Union[str, Path]] = None
     project: Project
     subject: Subject
     anatomy_type: str = Field(min_length=1)
@@ -96,7 +96,7 @@ class Landmarks(ApiModel):
     _endpoint = 'landmarks'
     _file_fields = {'file': 'core.Landmarks.file'}
 
-    file_source: Union[Path, str]
+    file_source: Union[str, Path]
     subject: Subject
     anatomy_type: str = Field(min_length=1)
     project: Project
@@ -106,7 +106,7 @@ class Constraints(ApiModel):
     _endpoint = 'constraints'
     _file_fields = {'file': 'core.Constraints.file'}
 
-    file_source: Union[Path, str]
+    file_source: Union[str, Path]
     subject: Subject
     anatomy_type: str = Field(min_length=1)
     optimized_particles: Optional[OptimizedParticles]
@@ -119,8 +119,8 @@ class CachedAnalysisGroup(ApiModel):
         'particles': 'core.CachedAnalysisGroup.particles',
     }
 
-    file_source: Union[Path, str]
-    particles_source: Optional[Union[Path, str]] = None
+    file_source: Union[str, Path]
+    particles_source: Optional[Union[str, Path]] = None
     name: str = Field(min_length=1)
     group1: str = Field(min_length=1)
     group2: str = Field(min_length=1)
@@ -136,8 +136,8 @@ class CachedAnalysisModePCA(ApiModel):
 
     pca_value: float
     lambda_value: float
-    file_source: Union[Path, str]
-    particles_source: Optional[Union[Path, str]] = None
+    file_source: Union[str, Path]
+    particles_source: Optional[Union[str, Path]] = None
 
 
 class CachedAnalysisMode(ApiModel):
@@ -157,8 +157,8 @@ class CachedAnalysisMeanShape(ApiModel):
         'particles': 'core.CachedAnalysisMeanShape.particles',
     }
 
-    file_source: Union[Path, str]
-    particles_source: Optional[Union[Path, str]] = None
+    file_source: Union[str, Path]
+    particles_source: Optional[Union[str, Path]] = None
 
 
 class CachedAnalysis(ApiModel):

--- a/swcc/swcc/models/other_models.py
+++ b/swcc/swcc/models/other_models.py
@@ -11,16 +11,16 @@ except ImportError:
         Literal,
     )
 
+from pydantic.v1 import Field
 from .api_model import ApiModel
 from .file_type import FileType
-from .utils import NonEmptyString
 
 
 class Segmentation(ApiModel):
     _endpoint = 'segmentations'
 
     file: FileType[Literal['core.Segmentation.file']]
-    anatomy_type: NonEmptyString
+    anatomy_type: str = Field(min_length=1)
     subject: Subject
 
 
@@ -28,7 +28,7 @@ class Mesh(ApiModel):
     _endpoint = 'meshes'
 
     file: FileType[Literal['core.Mesh.file']]
-    anatomy_type: NonEmptyString
+    anatomy_type: str = Field(min_length=1)
     subject: Subject
 
 
@@ -36,7 +36,7 @@ class Contour(ApiModel):
     _endpoint = 'contours'
 
     file: FileType[Literal['core.Contour.file']]
-    anatomy_type: NonEmptyString
+    anatomy_type: str = Field(min_length=1)
     subject: Subject
 
 
@@ -78,7 +78,7 @@ class OptimizedParticles(ApiModel):
     transform: Optional[FileType[Literal['core.OptimizedParticles.transform']]]
     project: Project
     subject: Subject
-    anatomy_type: NonEmptyString
+    anatomy_type: str = Field(min_length=1)
     groomed_segmentation: Optional[GroomedSegmentation]
     groomed_mesh: Optional[GroomedMesh]
 
@@ -88,7 +88,7 @@ class Landmarks(ApiModel):
 
     file: Optional[FileType[Literal['core.Landmarks.file']]]
     subject: Subject
-    anatomy_type: NonEmptyString
+    anatomy_type: str = Field(min_length=1)
     project: Project
 
 
@@ -97,7 +97,7 @@ class Constraints(ApiModel):
 
     file: Optional[FileType[Literal['core.Constraints.file']]]
     subject: Subject
-    anatomy_type: NonEmptyString
+    anatomy_type: str = Field(min_length=1)
     optimized_particles: Optional[OptimizedParticles]
 
 
@@ -106,9 +106,9 @@ class CachedAnalysisGroup(ApiModel):
 
     file: FileType[Literal['core.CachedAnalysisGroup.file']]
     particles: Optional[FileType[Literal['core.CachedAnalysisGroup.particles']]]
-    name: NonEmptyString
-    group1: NonEmptyString
-    group2: NonEmptyString
+    name: str = Field(min_length=1)
+    group1: str = Field(min_length=1)
+    group2: str = Field(min_length=1)
     ratio: float
 
 

--- a/swcc/swcc/models/other_models.py
+++ b/swcc/swcc/models/other_models.py
@@ -10,42 +10,34 @@ from .api_model import ApiModel
 
 class Segmentation(ApiModel):
     _endpoint = 'segmentations'
+    _file_fields = {'file': 'core.Segmentation.file'}
 
     file_source: Union[Path, str]
     anatomy_type: str = Field(min_length=1)
     subject: Subject
-
-    @property
-    def file(self):
-        return File(self.file_source, field_id='core.Segmentation.file')
 
 
 class Mesh(ApiModel):
     _endpoint = 'meshes'
+    _file_fields = {'file': 'core.Mesh.file'}
 
     file_source: Union[Path, str]
     anatomy_type: str = Field(min_length=1)
     subject: Subject
-
-    @property
-    def file(self):
-        return File(self.file_source, field_id='core.Mesh.file')
 
 
 class Contour(ApiModel):
     _endpoint = 'contours'
+    _file_fields = {'file': 'core.Contour.file'}
 
     file_source: Union[Path, str]
     anatomy_type: str = Field(min_length=1)
     subject: Subject
 
-    @property
-    def file(self):
-        return File(self.file_source, field_id='core.Contour.file')
-
 
 class Image(ApiModel):
     _endpoint = 'images'
+    _file_fields = {'file': 'core.Image.file'}
 
     file_source: Union[Path, str]
     modality: str
@@ -54,6 +46,11 @@ class Image(ApiModel):
 
 class GroomedSegmentation(ApiModel):
     _endpoint = 'groomed-segmentations'
+    _file_fields = {
+        'file': 'core.GroomedSegmentation.file',
+        'pre_cropping': 'core.GroomedSegmentation.pre_cropping',
+        'pre_alignment': 'core.GroomedSegmentation.pre_alignment',
+    }
 
     file_source: Union[Path, str]
     pre_cropping_source: Optional[Union[Path, str]] = None
@@ -61,21 +58,14 @@ class GroomedSegmentation(ApiModel):
     segmentation: Segmentation
     project: Project
 
-    @property
-    def file(self):
-        return File(self.file_source, field_id='core.GroomedSegmentation.file')
-
-    @property
-    def pre_cropping(self):
-        return File(self.pre_cropping_source, field_id='core.GroomedSegmentation.pre_cropping')
-
-    @property
-    def pre_alignment(self):
-        return File(self.pre_alignment_source, field_id='core.GroomedSegmentation.pre_alignment')
-
 
 class GroomedMesh(ApiModel):
     _endpoint = 'groomed-meshes'
+    _file_fields = {
+        'file': 'core.GroomedMesh.file',
+        'pre_cropping': 'core.GroomedMesh.pre_cropping',
+        'pre_alignment': 'core.GroomedMesh.pre_alignment',
+    }
 
     file_source: Union[Path, str]
     pre_cropping_source: Optional[Union[Path, str]] = None
@@ -83,21 +73,14 @@ class GroomedMesh(ApiModel):
     mesh: Mesh
     project: Project
 
-    @property
-    def file(self):
-        return File(self.file_source, field_id='core.GroomedMesh.file')
-
-    @property
-    def pre_cropping(self):
-        return File(self.pre_cropping_source, field_id='core.GroomedMesh.pre_cropping')
-
-    @property
-    def pre_alignment(self):
-        return File(self.pre_alignment_source, field_id='core.GroomedMesh.pre_alignment')
-
 
 class OptimizedParticles(ApiModel):
     _endpoint = 'optimized-particles'
+    _file_fields = {
+        'world': 'core.OptimizedParticles.world',
+        'local': 'core.OptimizedParticles.local',
+        'transform': 'core.OptimizedParticles.transform',
+    }
 
     world_source: Optional[Union[Path, str]] = None
     local_source: Optional[Union[Path, str]] = None
@@ -108,47 +91,33 @@ class OptimizedParticles(ApiModel):
     groomed_segmentation: Optional[GroomedSegmentation]
     groomed_mesh: Optional[GroomedMesh]
 
-    @property
-    def world(self):
-        return File(self.world_source, field_id='core.OptimizedParticles.world')
-
-    @property
-    def local(self):
-        return File(self.local_source, field_id='core.OptimizedParticles.local')
-
-    @property
-    def transform(self):
-        return File(self.transform_source, field_id='core.OptimizedParticles.transform')
-
 
 class Landmarks(ApiModel):
     _endpoint = 'landmarks'
+    _file_fields = {'file': 'core.Landmarks.file'}
 
     file_source: Union[Path, str]
     subject: Subject
     anatomy_type: str = Field(min_length=1)
     project: Project
 
-    @property
-    def file(self):
-        return File(self.file_source, field_id='core.Landmarks.file')
-
 
 class Constraints(ApiModel):
     _endpoint = 'constraints'
+    _file_fields = {'file': 'core.Constraints.file'}
 
     file_source: Union[Path, str]
     subject: Subject
     anatomy_type: str = Field(min_length=1)
     optimized_particles: Optional[OptimizedParticles]
 
-    @property
-    def file(self):
-        return File(self.file_source, field_id='core.Constraints.file')
-
 
 class CachedAnalysisGroup(ApiModel):
     _endpoint = 'cached-analysis-group'
+    _file_fields = {
+        'file': 'core.CachedAnalysisGroup.file',
+        'particles': 'core.CachedAnalysisGroup.particles',
+    }
 
     file_source: Union[Path, str]
     particles_source: Optional[Union[Path, str]] = None
@@ -157,30 +126,18 @@ class CachedAnalysisGroup(ApiModel):
     group2: str = Field(min_length=1)
     ratio: float
 
-    @property
-    def file(self):
-        return File(self.file_source, field_id='core.CachedAnalysisGroup.file')
-
-    @property
-    def particles(self):
-        return File(self.particles_source, field_id='core.CachedAnalysisGroup.particles')
-
 
 class CachedAnalysisModePCA(ApiModel):
     _endpoint = 'cached-analysis-mode-pca'
+    _file_fields = {
+        'file': 'core.CachedAnalysisModePCA.file',
+        'particles': 'core.CachedAnalysisModePCA.particles',
+    }
 
     pca_value: float
     lambda_value: float
     file_source: Union[Path, str]
     particles_source: Optional[Union[Path, str]] = None
-
-    @property
-    def file(self):
-        return File(self.file_source, field_id='core.CachedAnalysisModePCA.file')
-
-    @property
-    def particles(self):
-        return File(self.particles_source, field_id='core.CachedAnalysisModePCA.particles')
 
 
 class CachedAnalysisMode(ApiModel):
@@ -195,17 +152,13 @@ class CachedAnalysisMode(ApiModel):
 
 class CachedAnalysisMeanShape(ApiModel):
     _endpoint = 'cached-analysis-mean-shape'
+    _file_fields = {
+        'file': 'core.CachedAnalysisMeanShape.file',
+        'particles': 'core.CachedAnalysisMeanShape.particles',
+    }
 
     file_source: Union[Path, str]
     particles_source: Optional[Union[Path, str]] = None
-
-    @property
-    def file(self):
-        return File(self.file_source, field_id='core.CachedAnalysisMeanShape.file')
-
-    @property
-    def particles(self):
-        return File(self.particles_source, field_id='core.CachedAnalysisMeanShape.particles')
 
 
 class CachedAnalysis(ApiModel):
@@ -220,8 +173,6 @@ class CachedAnalysis(ApiModel):
 
 from .project import Project  # noqa: E402
 from .subject import Subject  # noqa: E402
-from .file import File  # noqa: E402
-
 
 Segmentation.update_forward_refs()
 Mesh.update_forward_refs()

--- a/swcc/swcc/models/other_models.py
+++ b/swcc/swcc/models/other_models.py
@@ -1,49 +1,53 @@
 from __future__ import annotations
 
-try:
-    from typing import List, Literal, Optional
-except ImportError:
-    from typing import (
-        List,
-        Optional,
-    )
-    from typing_extensions import (  # type: ignore
-        Literal,
-    )
+from pathlib import Path
+from typing import List, Optional, Union
 
 from pydantic.v1 import Field
+
 from .api_model import ApiModel
-from .file_type import FileType
 
 
 class Segmentation(ApiModel):
     _endpoint = 'segmentations'
 
-    file: FileType[Literal['core.Segmentation.file']]
+    file_source: Union[Path, str]
     anatomy_type: str = Field(min_length=1)
     subject: Subject
+
+    @property
+    def file(self):
+        return File(self.file_source, field_id='core.Segmentation.file')
 
 
 class Mesh(ApiModel):
     _endpoint = 'meshes'
 
-    file: FileType[Literal['core.Mesh.file']]
+    file_source: Union[Path, str]
     anatomy_type: str = Field(min_length=1)
     subject: Subject
+
+    @property
+    def file(self):
+        return File(self.file_source, field_id='core.Mesh.file')
 
 
 class Contour(ApiModel):
     _endpoint = 'contours'
 
-    file: FileType[Literal['core.Contour.file']]
+    file_source: Union[Path, str]
     anatomy_type: str = Field(min_length=1)
     subject: Subject
+
+    @property
+    def file(self):
+        return File(self.file_source, field_id='core.Contour.file')
 
 
 class Image(ApiModel):
     _endpoint = 'images'
 
-    file: FileType[Literal['core.Image.file']]
+    file_source: Union[Path, str]
     modality: str
     subject: Subject
 
@@ -51,65 +55,115 @@ class Image(ApiModel):
 class GroomedSegmentation(ApiModel):
     _endpoint = 'groomed-segmentations'
 
-    file: Optional[FileType[Literal['core.GroomedSegmentation.file']]]
-    pre_cropping: Optional[FileType[Literal['core.GroomedSegmentation.pre_cropping']]] = None
-    pre_alignment: Optional[FileType[Literal['core.GroomedSegmentation.pre_alignment']]] = None
-
+    file_source: Union[Path, str]
+    pre_cropping_source: Optional[Union[Path, str]] = None
+    pre_alignment_source: Optional[Union[Path, str]] = None
     segmentation: Segmentation
     project: Project
+
+    @property
+    def file(self):
+        return File(self.file_source, field_id='core.GroomedSegmentation.file')
+
+    @property
+    def pre_cropping(self):
+        return File(self.pre_cropping_source, field_id='core.GroomedSegmentation.pre_cropping')
+
+    @property
+    def pre_alignment(self):
+        return File(self.pre_alignment_source, field_id='core.GroomedSegmentation.pre_alignment')
 
 
 class GroomedMesh(ApiModel):
     _endpoint = 'groomed-meshes'
 
-    file: Optional[FileType[Literal['core.GroomedMesh.file']]]
-    pre_cropping: Optional[FileType[Literal['core.GroomedMesh.pre_cropping']]] = None
-    pre_alignment: Optional[FileType[Literal['core.GroomedMesh.pre_alignment']]] = None
-
+    file_source: Union[Path, str]
+    pre_cropping_source: Optional[Union[Path, str]] = None
+    pre_alignment_source: Optional[Union[Path, str]] = None
     mesh: Mesh
     project: Project
+
+    @property
+    def file(self):
+        return File(self.file_source, field_id='core.GroomedMesh.file')
+
+    @property
+    def pre_cropping(self):
+        return File(self.pre_cropping_source, field_id='core.GroomedMesh.pre_cropping')
+
+    @property
+    def pre_alignment(self):
+        return File(self.pre_alignment_source, field_id='core.GroomedMesh.pre_alignment')
 
 
 class OptimizedParticles(ApiModel):
     _endpoint = 'optimized-particles'
 
-    world: Optional[FileType[Literal['core.OptimizedParticles.world']]]
-    local: Optional[FileType[Literal['core.OptimizedParticles.local']]]
-    transform: Optional[FileType[Literal['core.OptimizedParticles.transform']]]
+    world_source: Optional[Union[Path, str]] = None
+    local_source: Optional[Union[Path, str]] = None
+    transform_source: Optional[Union[Path, str]] = None
     project: Project
     subject: Subject
     anatomy_type: str = Field(min_length=1)
     groomed_segmentation: Optional[GroomedSegmentation]
     groomed_mesh: Optional[GroomedMesh]
 
+    @property
+    def world(self):
+        return File(self.world_source, field_id='core.OptimizedParticles.world')
+
+    @property
+    def local(self):
+        return File(self.local_source, field_id='core.OptimizedParticles.local')
+
+    @property
+    def transform(self):
+        return File(self.transform_source, field_id='core.OptimizedParticles.transform')
+
 
 class Landmarks(ApiModel):
     _endpoint = 'landmarks'
 
-    file: Optional[FileType[Literal['core.Landmarks.file']]]
+    file_source: Union[Path, str]
     subject: Subject
     anatomy_type: str = Field(min_length=1)
     project: Project
+
+    @property
+    def file(self):
+        return File(self.file_source, field_id='core.Landmarks.file')
 
 
 class Constraints(ApiModel):
     _endpoint = 'constraints'
 
-    file: Optional[FileType[Literal['core.Constraints.file']]]
+    file_source: Union[Path, str]
     subject: Subject
     anatomy_type: str = Field(min_length=1)
     optimized_particles: Optional[OptimizedParticles]
+
+    @property
+    def file(self):
+        return File(self.file_source, field_id='core.Constraints.file')
 
 
 class CachedAnalysisGroup(ApiModel):
     _endpoint = 'cached-analysis-group'
 
-    file: FileType[Literal['core.CachedAnalysisGroup.file']]
-    particles: Optional[FileType[Literal['core.CachedAnalysisGroup.particles']]]
+    file_source: Union[Path, str]
+    particles_source: Optional[Union[Path, str]] = None
     name: str = Field(min_length=1)
     group1: str = Field(min_length=1)
     group2: str = Field(min_length=1)
     ratio: float
+
+    @property
+    def file(self):
+        return File(self.file_source, field_id='core.CachedAnalysisGroup.file')
+
+    @property
+    def particles(self):
+        return File(self.particles_source, field_id='core.CachedAnalysisGroup.particles')
 
 
 class CachedAnalysisModePCA(ApiModel):
@@ -117,8 +171,16 @@ class CachedAnalysisModePCA(ApiModel):
 
     pca_value: float
     lambda_value: float
-    file: FileType[Literal['core.CachedAnalysisModePCA.file']]
-    particles: FileType[Literal['core.CachedAnalysisModePCA.particles']]
+    file_source: Union[Path, str]
+    particles_source: Optional[Union[Path, str]] = None
+
+    @property
+    def file(self):
+        return File(self.file_source, field_id='core.CachedAnalysisModePCA.file')
+
+    @property
+    def particles(self):
+        return File(self.particles_source, field_id='core.CachedAnalysisModePCA.particles')
 
 
 class CachedAnalysisMode(ApiModel):
@@ -134,8 +196,16 @@ class CachedAnalysisMode(ApiModel):
 class CachedAnalysisMeanShape(ApiModel):
     _endpoint = 'cached-analysis-mean-shape'
 
-    file: FileType[Literal['core.CachedAnalysisMeanShape.file']]
-    particles: FileType[Literal['core.CachedAnalysisMeanShape.particles']]
+    file_source: Union[Path, str]
+    particles_source: Optional[Union[Path, str]] = None
+
+    @property
+    def file(self):
+        return File(self.file_source, field_id='core.CachedAnalysisMeanShape.file')
+
+    @property
+    def particles(self):
+        return File(self.particles_source, field_id='core.CachedAnalysisMeanShape.particles')
 
 
 class CachedAnalysis(ApiModel):
@@ -150,6 +220,8 @@ class CachedAnalysis(ApiModel):
 
 from .project import Project  # noqa: E402
 from .subject import Subject  # noqa: E402
+from .file import File  # noqa: E402
+
 
 Segmentation.update_forward_refs()
 Mesh.update_forward_refs()

--- a/swcc/swcc/models/project.py
+++ b/swcc/swcc/models/project.py
@@ -325,8 +325,8 @@ class Project(ApiModel):
     creator: Optional[str] = ''
     dataset: Dataset
     # sent in as a filepath string, interpreted as CachedAnalysis object
-    last_cached_analysis: Optional[Any]
-    landmarks_info: Optional[Any]
+    last_cached_analysis: Optional[Any] = None
+    landmarks_info: Optional[Any] = None
 
     def get_file_io(self):
         return ProjectFileIO(project=self)

--- a/swcc/swcc/models/project.py
+++ b/swcc/swcc/models/project.py
@@ -3,31 +3,17 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from typing import Any, Dict, Iterator, Optional, Union
 import warnings
 
-import requests
-
-try:
-    from typing import Any, Dict, Iterator, Literal, Optional, Union
-except ImportError:
-    from typing import (
-        Any,
-        Dict,
-        Iterator,
-        Optional,
-        Union,
-    )
-    from typing_extensions import (  # type: ignore
-        Literal,
-    )
-
 from pydantic.v1 import BaseModel
+import requests
 
 from ..api import current_session
 from .api_model import ApiModel
 from .constants import expected_key_prefixes, required_key_prefixes
 from .dataset import Dataset
-from .file_type import FileType
+from .file import File
 from .other_models import (
     CachedAnalysis,
     CachedAnalysisGroup,
@@ -155,38 +141,38 @@ class ProjectFileIO(BaseModel, FileIO):
 
                     if key == 'mesh':
                         original_shape = Mesh(
-                            file=relative_path(value),
+                            file_source=relative_path(value),
                             anatomy_type=anatomy_id,
                             subject=subject,
                         ).create()
                     elif key == 'segmentation':
                         original_shape = Segmentation(
-                            file=relative_path(value),
+                            file_source=relative_path(value),
                             anatomy_type=anatomy_id,
                             subject=subject,
                         ).create()
                         pass
                     elif key == 'contour':
                         original_shape = Contour(
-                            file=relative_path(value),
+                            file_source=relative_path(value),
                             anatomy_type=anatomy_id,
                             subject=subject,
                         ).create()
                     elif key == 'image':
                         Image(
-                            file=relative_path(value),
+                            file_source=relative_path(value),
                             modality=anatomy_id,
                             subject=subject,
                         ).create()
                     elif key == 'groomed':
                         if type(original_shape) == Mesh:
                             groomed_shape = self.project.add_groomed_mesh(
-                                file=relative_path(value),
+                                file_source=relative_path(value),
                                 mesh=original_shape,
                             )
                         elif type(original_shape) == Segmentation:
                             groomed_shape = self.project.add_groomed_segmentation(
-                                file=relative_path(value),
+                                file_source=relative_path(value),
                                 segmentation=original_shape,
                             )
                     elif key == 'local':
@@ -199,7 +185,7 @@ class ProjectFileIO(BaseModel, FileIO):
                             f.write(value)
                     elif key == 'landmarks':
                         Landmarks(
-                            file=relative_path(value),
+                            file_source=relative_path(value),
                             subject=subject,
                             project=self.project,
                             anatomy_type=anatomy_id,
@@ -211,14 +197,14 @@ class ProjectFileIO(BaseModel, FileIO):
                 if world_particles_path or local_particles_path:
                     groomed_mesh = None
                     groomed_segmentation = None
-                    if type(original_shape) == Mesh:
+                    if type(groomed_shape) == GroomedMesh:
                         groomed_mesh = groomed_shape
-                    elif type(original_shape) == Segmentation:
+                    elif type(groomed_shape) == GroomedSegmentation:
                         groomed_segmentation = groomed_shape
                     particles = OptimizedParticles(
-                        world=world_particles_path,
-                        local=local_particles_path,
-                        transform=transform,
+                        world_source=world_particles_path,
+                        local_source=local_particles_path,
+                        transform_source=transform,
                         groomed_segmentation=groomed_segmentation,
                         groomed_mesh=groomed_mesh,
                         project=self.project,
@@ -227,7 +213,7 @@ class ProjectFileIO(BaseModel, FileIO):
                     ).create()
                 if constraints_path:
                     Constraints(
-                        file=constraints_path,
+                        file_source=constraints_path,
                         subject=subject,
                         optimized_particles=particles,
                         anatomy_type=anatomy_id,
@@ -250,8 +236,8 @@ class ProjectFileIO(BaseModel, FileIO):
 
             for i in range(len(mean_shapes)):
                 cams = CachedAnalysisMeanShape(
-                    file=mean_shapes[i],
-                    particles=mean_particles[i] if mean_particles else None,
+                    file_source=mean_shapes[i],
+                    particles_source=mean_particles[i] if mean_particles else None,
                 ).create()
                 mean_shapes_cache.append(cams)
 
@@ -269,8 +255,9 @@ class ProjectFileIO(BaseModel, FileIO):
                         cam_pca = CachedAnalysisModePCA(
                             pca_value=pca['pca_value'],
                             lambda_value=pca['lambda'],
-                            file=analysis_file_location.parent / Path(pca['meshes'][i]),
-                            particles=analysis_file_location.parent / Path(pca['particles'][i]),
+                            file_source=analysis_file_location.parent / Path(pca['meshes'][i]),
+                            particles_source=analysis_file_location.parent
+                            / Path(pca['particles'][i]),
                         ).create()
                         pca_values.append(cam_pca)
                         i += 1
@@ -295,10 +282,10 @@ class ProjectFileIO(BaseModel, FileIO):
                                     group1=group['group1'],
                                     group2=group['group2'],
                                     ratio=values['ratio'],
-                                    file=(
+                                    file_source=(
                                         analysis_file_location.parent / Path(values['meshes'][i])
                                     ),
-                                    particles=(
+                                    particles_source=(
                                         analysis_file_location.parent / Path(values['particles'][i])
                                     ),
                                 ).create()
@@ -319,7 +306,7 @@ class Project(ApiModel):
     private: bool = False
     readonly: bool = False
     name: str = 'My Project'
-    file: FileType[Literal['core.Project.file']]
+    file_source: Union[Path, str]
     keywords: str = ''
     description: str = ''
     creator: Optional[str] = ''
@@ -330,6 +317,10 @@ class Project(ApiModel):
 
     def get_file_io(self):
         return ProjectFileIO(project=self)
+
+    @property
+    def file(self):
+        return File(self.file_source, field_id='core.Project.file')
 
     @property
     def subjects(self) -> Iterator[Subject]:
@@ -347,32 +338,32 @@ class Project(ApiModel):
 
     def add_groomed_segmentation(
         self,
-        file: Path,
+        file_source: Path,
         segmentation: Segmentation,
-        pre_cropping: Optional[Path] = None,
-        pre_alignment: Optional[Path] = None,
+        pre_cropping_source: Optional[Path] = None,
+        pre_alignment_source: Optional[Path] = None,
     ) -> GroomedSegmentation:
         return GroomedSegmentation(
-            file=file,
+            file_source=file_source,
             segmentation=segmentation,
             project=self,
-            pre_cropping=pre_cropping,
-            pre_alignment=pre_alignment,
+            pre_cropping_source=pre_cropping_source,
+            pre_alignment_source=pre_alignment_source,
         ).create()
 
     def add_groomed_mesh(
         self,
-        file: Path,
+        file_source: Path,
         mesh: Mesh,
-        pre_cropping: Optional[Path] = None,
-        pre_alignment: Optional[Path] = None,
+        pre_cropping_source: Optional[Path] = None,
+        pre_alignment_source: Optional[Path] = None,
     ) -> GroomedMesh:
         return GroomedMesh(
-            file=file,
+            file_source=file_source,
             mesh=mesh,
             project=self,
-            pre_cropping=pre_cropping,
-            pre_alignment=pre_alignment,
+            pre_cropping_source=pre_cropping_source,
+            pre_alignment_source=pre_alignment_source,
         ).create()
 
     @property
@@ -413,7 +404,7 @@ class Project(ApiModel):
         if len(files):
             print_progress_bar(0, len(files))
             for index, (path, url) in enumerate(files.items()):
-                file_item: FileType = FileType(url=url)
+                file_item: File = File(url)
                 file_item.download(Path(folder, *path.split('/')[:-1]))
                 print_progress_bar(index + 1, len(files))
         session.close()

--- a/swcc/swcc/models/project.py
+++ b/swcc/swcc/models/project.py
@@ -307,7 +307,7 @@ class Project(ApiModel):
     private: bool = False
     readonly: bool = False
     name: str = 'My Project'
-    file_source: Union[Path, str]
+    file_source: Union[str, Path]
     keywords: str = ''
     description: str = ''
     creator: Optional[str] = ''
@@ -390,7 +390,7 @@ class Project(ApiModel):
         assert result.id
         return Project.from_id(result.id)
 
-    def download(self, folder: Union[Path, str]):
+    def download(self, folder: Union[str, Path]):
         session = current_session()
         self.file.download(folder)
         r: requests.Response = session.get(f'{self._endpoint}/{self.id}/download/')

--- a/swcc/swcc/models/project.py
+++ b/swcc/swcc/models/project.py
@@ -302,6 +302,7 @@ class ProjectFileIO(BaseModel, FileIO):
 
 class Project(ApiModel):
     _endpoint = 'projects'
+    _file_fields = {'file': 'core.Project.file'}
 
     private: bool = False
     readonly: bool = False
@@ -317,10 +318,6 @@ class Project(ApiModel):
 
     def get_file_io(self):
         return ProjectFileIO(project=self)
-
-    @property
-    def file(self):
-        return File(self.file_source, field_id='core.Project.file')
 
     @property
     def subjects(self) -> Iterator[Subject]:

--- a/swcc/swcc/models/subject.py
+++ b/swcc/swcc/models/subject.py
@@ -1,19 +1,19 @@
 from pathlib import Path
 from typing import Dict, Iterator, List, Optional
+from pydantic.v1 import Field
 
 from .api_model import ApiModel
 from .dataset import Dataset
 from .other_models import Constraints, Contour, Image, Landmarks, Mesh, Segmentation
-from .utils import NonEmptyString
 
 
 class Subject(ApiModel):
     _endpoint = 'subjects'
 
-    name: NonEmptyString
+    name: str = Field(min_length=3, max_length=255)
     dataset: Dataset
     groups: Optional[Dict[str, str]]
-    num_domains: Optional[int]
+    num_domains: Optional[int] = None
 
     @property
     def segmentations(self) -> Iterator[Segmentation]:

--- a/swcc/swcc/models/subject.py
+++ b/swcc/swcc/models/subject.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from typing import Dict, Iterator, List, Optional
+
 from pydantic.v1 import Field
 
 from .api_model import ApiModel
@@ -40,16 +41,16 @@ class Subject(ApiModel):
         return Constraints.list(subject=self)
 
     def add_segmentation(self, file: Path, anatomy_type: str) -> Segmentation:
-        return Segmentation(file=file, anatomy_type=anatomy_type, subject=self).create()
+        return Segmentation(file_source=file, anatomy_type=anatomy_type, subject=self).create()
 
     def add_mesh(self, file: Path, anatomy_type: str) -> Mesh:
-        return Mesh(file=file, anatomy_type=anatomy_type, subject=self).create()
+        return Mesh(file_source=file, anatomy_type=anatomy_type, subject=self).create()
 
     def add_contour(self, file: Path, anatomy_type: str) -> Contour:
-        return Contour(file=file, anatomy_type=anatomy_type, subject=self).create()
+        return Contour(file_source=file, anatomy_type=anatomy_type, subject=self).create()
 
     def add_image(self, file: Path, modality: str) -> Image:
-        return Image(file=file, modality=modality, subject=self).create()
+        return Image(file_source=file, modality=modality, subject=self).create()
 
     @classmethod
     def from_name_and_dataset(cls, name: str, dataset: Dataset):

--- a/swcc/swcc/models/utils.py
+++ b/swcc/swcc/models/utils.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from typing import Any, Iterable, Optional
 
 import click
-from pydantic import StrictStr
 import requests
 import toml
 from tqdm import tqdm
@@ -28,10 +27,6 @@ class FileIO(ABC):
     @abstractmethod
     def interpret_data(self, data, root):
         pass
-
-
-class NonEmptyString(StrictStr):
-    min_length = 1
 
 
 def shape_file_type(path: Path):

--- a/swcc/tests/factories.py
+++ b/swcc/tests/factories.py
@@ -64,7 +64,7 @@ class SegmentationFactory(Factory):
     class Meta:
         model = models.Segmentation
 
-    file = Faker('file', extension='nrrd')
+    file_source = Faker('file', extension='nrrd')
     anatomy_type = Faker('word')
     subject = SubFactory(SubjectFactory)
 
@@ -73,7 +73,7 @@ class MeshFactory(Factory):
     class Meta:
         model = models.Mesh
 
-    file = Faker('file', extension='ply')
+    file_source = Faker('file', extension='ply')
     anatomy_type = Faker('word')
     subject = SubFactory(SubjectFactory)
 
@@ -82,7 +82,7 @@ class ImageFactory(Factory):
     class Meta:
         model = models.Image
 
-    file = Faker('file', extension='nrrd')
+    file_source = Faker('file', extension='nrrd')
     modality = Faker('word')
     subject = SubFactory(SubjectFactory)
 
@@ -91,7 +91,7 @@ class ProjectFactory(Factory):
     class Meta:
         model = models.Project
 
-    file = './tests/test_data/project_demo.swproj'
+    file_source = './tests/test_data/project_demo.swproj'
     keywords = Faker('word')
     description = Faker('sentence')
     dataset = SubFactory(DatasetFactory)
@@ -101,9 +101,9 @@ class GroomedSegmentationFactory(Factory):
     class Meta:
         model = models.GroomedSegmentation
 
-    file = Faker('file', extension='nrrd')
-    pre_cropping = Faker('file', extension='txt', null_chance=50)
-    pre_alignment = Faker('file', extension='txt', null_chance=50)
+    file_source = Faker('file', extension='nrrd')
+    pre_cropping_source = Faker('file', extension='txt', null_chance=50)
+    pre_alignment_source = Faker('file', extension='txt', null_chance=50)
 
     segmentation = SubFactory(SegmentationFactory)
     project = SubFactory(ProjectFactory)
@@ -113,9 +113,9 @@ class GroomedMeshFactory(Factory):
     class Meta:
         model = models.GroomedMesh
 
-    file = Faker('file', extension='ply')
-    pre_cropping = Faker('file', extension='txt', null_chance=50)
-    pre_alignment = Faker('file', extension='txt', null_chance=50)
+    file_source = Faker('file', extension='ply')
+    pre_cropping_source = Faker('file', extension='txt', null_chance=50)
+    pre_alignment_source = Faker('file', extension='txt', null_chance=50)
 
     mesh = SubFactory(MeshFactory)
     project = SubFactory(ProjectFactory)
@@ -125,9 +125,9 @@ class OptimizedParticlesFactory(Factory):
     class Meta:
         model = models.OptimizedParticles
 
-    world = Faker('file', extension='txt')
-    local = Faker('file', extension='txt')
-    transform = Faker('file', extension='txt')
+    world_source = Faker('file', extension='txt')
+    local_source = Faker('file', extension='txt')
+    transform_source = Faker('file', extension='txt')
     project = SubFactory(ProjectFactory)
     subject = SubFactory(SubjectFactory)
     anatomy_type = Faker('word')

--- a/swcc/tests/test_download_upload.py
+++ b/swcc/tests/test_download_upload.py
@@ -84,7 +84,7 @@ def test_download_upload_cycle(session):
                 models.Project(
                     dataset=d,
                     name=project.name,
-                    file=project.file.path,
+                    file_source=project.file.path,
                     private=project.private,
                     readonly=project.readonly,
                     description=project.description,

--- a/swcc/tests/test_download_upload.py
+++ b/swcc/tests/test_download_upload.py
@@ -18,7 +18,10 @@ def project_as_dict_repr(project):
 
     # remove keys that are expected to differ between servers
     del project_repr['id']
-    del project_repr['file']
+    if 'file' in project_repr:
+        del project_repr['file']
+    if 'file_source' in project_repr:
+        del project_repr['file_source']
     del project_repr['creator']
     del project_repr['dataset']['id']
     del project_repr['dataset']['creator']
@@ -54,9 +57,10 @@ def public_server_download(download_dir):
         dataset_subset = (
             random.sample(tiny_tests, SAMPLE_SIZE) if len(tiny_tests) >= SAMPLE_SIZE else tiny_tests
         )
-        project_subset = [next(d.projects) for d in dataset_subset]
+        project_subset = [next(d.projects, None) for d in dataset_subset]
         for project in project_subset:
-            project.download(download_dir)
+            if project is not None:
+                project.download(download_dir)
         return project_subset
 
 

--- a/swcc/tests/test_models.py
+++ b/swcc/tests/test_models.py
@@ -35,7 +35,7 @@ def test_file_download_api(session):
         file = directory / 'test_file.nrrd'
         with file.open('w') as f:
             f.write('file content')
-        segmentation = factories.SegmentationFactory(file=file).create()
+        segmentation = factories.SegmentationFactory(file_source=file).create()
         segmentation = models.Segmentation.from_id(segmentation.id)
 
         assert file.name in segmentation.file.url

--- a/swcc/tox.ini
+++ b/swcc/tox.ini
@@ -25,7 +25,7 @@ commands =
 skip_install = false
 usedevelop = true
 deps =
-    mypy<0.920
+    mypy
     types-requests
     types-toml
     types-click

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ skipsdist = true
 skip_install = false
 usedevelop = true
 deps =
-    mypy<0.920
+    mypy
     django-stubs<2
     djangorestframework-stubs
 commands =


### PR DESCRIPTION
Resolves #351. This is related to the current failure on #355, which contains the following traceback:
```
type: commands[0]> mypy . --exclude=build/
/home/runner/work/shapeworks-cloud/shapeworks-cloud/swcc/.tox/type/lib/python3.8/site-packages/pydantic/__init__.py:45: error: INTERNAL ERROR -- Please try using mypy master on Github:
https://mypy.readthedocs.io/en/stable/common_issues.html#using-a-development-mypy-build
If this issue continues with mypy master, please report a bug at https://github.com/python/mypy/issues
version: 0.910
```

Inevitably, with the update to mypy, the type coercion we had been performing for `FileType` objects in SWCC is no longer allowed, so this typing update will introduce breaking changes. 

The SWCC `ApiModel` now separates File fields from their source fields, where the source field is typed as `Union[str, Path]`. **For every file-type field on an SWCC class, a `_source` suffix should be added to the attribute when calling the constructor.** For example, `project = Project(file=file_path)` becomes `project = Project(file_source=file_path)`. After this constructor change has been made, `project.file` is still accessible and will return a `File` object with attributes `path`, `url`, `field_id`, and `field_value`. This accessor to the `File` object is generated dynamically in `ApiModel.__getattribute__`.