### PR TITLE
fix: Specify username with `createsuperuser` cmd in CI jobs

### DIFF
--- a/.github/workflows/download_upload_cycle.yml
+++ b/.github/workflows/download_upload_cycle.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Run migrations
         run: docker-compose run --rm django ./manage.py migrate
       - name: Create super user
-        run: docker-compose run -e DJANGO_SUPERUSER_PASSWORD=$DJANGO_SUPERUSER_PASSWORD --rm django ./manage.py createsuperuser --noinput --email=$DJANGO_SUPERUSER_EMAIL
+        run: docker-compose run -e DJANGO_SUPERUSER_PASSWORD=$DJANGO_SUPERUSER_PASSWORD --rm django ./manage.py createsuperuser --noinput --email=$DJANGO_SUPERUSER_EMAIL --username=$DJANGO_SUPERUSER_EMAIL
       - name: Start server
         run: docker-compose up -d
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Run migrations
         run: docker-compose run --rm django ./manage.py migrate
       - name: Create super user
-        run: docker-compose run -e DJANGO_SUPERUSER_PASSWORD=$DJANGO_SUPERUSER_PASSWORD --rm django ./manage.py createsuperuser --noinput --email=$DJANGO_SUPERUSER_EMAIL
+        run: docker-compose run -e DJANGO_SUPERUSER_PASSWORD=$DJANGO_SUPERUSER_PASSWORD --rm django ./manage.py createsuperuser --noinput --email=$DJANGO_SUPERUSER_EMAIL --username=$DJANGO_SUPERUSER_EMAIL
       - name: Start server
         run: docker-compose up -d
 


### PR DESCRIPTION
CI jobs `test/client` and `download_upload_cycle/client` are failing with the following error during the `createsuperuser` step:
```
CommandError: You must use --username with --noinput.
```
https://github.com/girder/shapeworks-cloud/actions/runs/8233684648/job/22513686081?pr=355

This PR adds the `--username` flag to those instances of the `createsuperuser` command. The value passed is the same as the value passed to `--email`.