### PR TITLE
fix: (Charts) Analysis PCA charts not rendering

### DIFF
--- a/web/shapeworks/src/components/Analysis/AnalysisTab.vue
+++ b/web/shapeworks/src/components/Analysis/AnalysisTab.vue
@@ -118,6 +118,7 @@ export default {
                 </v-expansion-panel-header>
                 <v-expansion-panel-content>
                     <PCA ref="pca" :currentTab="currentTab" :openTab="openTab"/>
+                    <charts :charts="analysis.charts"/>
                 </v-expansion-panel-content>
             </v-expansion-panel>
             <v-expansion-panel :disabled="analysis.groups.length <= 0" id="groups-panel">
@@ -126,14 +127,6 @@ export default {
                 </v-expansion-panel-header>
                 <v-expansion-panel-content>
                     <groups ref="groups" :currentTab="currentTab" :openTab="openTab"/>
-                </v-expansion-panel-content>
-            </v-expansion-panel>
-            <v-expansion-panel>
-                <v-expansion-panel-header>
-                    Charts
-                </v-expansion-panel-header>
-                <v-expansion-panel-content>
-                    <charts :charts="analysis.charts"/>
                 </v-expansion-panel-content>
             </v-expansion-panel>
             <v-expansion-panel>


### PR DESCRIPTION
This PR fixes the issue where analysis charts weren't rendering.

Some experimenting revealed that the Analysis charts weren't rendering if they were in a CLOSED expansion panel on mount. By setting the default panel to the charts, they rendered and were cached in the browser.

To fix this and keep the PCA tab as default open tab for analysis, the charts component was moved into the PCA panel and the charts panel was removed. This behavior is still acceptable, as the charts are directly related to the PCA values generated.