### PR TITLE
Update error handle for training data-array

### DIFF
--- a/web/shapeworks/src/components/ShapeViewer/methods.js
+++ b/web/shapeworks/src/components/ShapeViewer/methods.js
@@ -249,7 +249,10 @@ export default {
                                 this.showDifferenceFromMean(mapper, renderer, label, domainIndex)
                             }
                             if ([1, 2].includes(deepSSMDataTab.value)) {
-                                const data = shapeData.getPointData().getArrayByName('deepssm_error').getData()
+                                let data;
+                                if (shapeData.getPointData().getArrayByName('deepssm_error')) {
+                                    data = shapeData.getPointData().getArrayByName('deepssm_error').getData()
+                                }
 
                                 if (data) {
                                     let normalizeRange;


### PR DESCRIPTION
Training data array was failing when pulling the data array, not when getting the data from the array. This adds a check to see if the data array exists in the VTK file.