### PR TITLE
Color scale bar error handling for missing deepssm_error

### DIFF
--- a/web/shapeworks/src/components/ShapeViewer/methods.js
+++ b/web/shapeworks/src/components/ShapeViewer/methods.js
@@ -436,11 +436,10 @@ export default {
                 let range = [-5, 5]
                 data[0].shape.forEach((shape) => {
                     if (shape.getClassName() === 'vtkPolyData') {
-                            const arr = shape.getPointData().getArrayByName('deepssm_error').getData()
-                            if (arr) range = [Math.min(...arr), Math.max(...arr)]
-                        } 
-                    }
-                )
+                        const arr = shape.getPointData().getArrayByName('deepssm_error').getData()
+                        if (arr) range = [Math.min(...arr), Math.max(...arr)]
+                    } 
+                })
                 this.prepareColorScale(canvas, labels, range)
             })
         }

--- a/web/shapeworks/src/components/ShapeViewer/methods.js
+++ b/web/shapeworks/src/components/ShapeViewer/methods.js
@@ -249,7 +249,10 @@ export default {
                                 this.showDifferenceFromMean(mapper, renderer, label, domainIndex)
                             }
                             if ([1, 2].includes(deepSSMDataTab.value)) {
-                                const data = shapeData.getPointData().getArrayByName('deepssm_error').getData()
+                                let data;
+                                if (shapeData.getPointData().getArrayByName('deepssm_error')) {
+                                    data = shapeData.getPointData().getArrayByName('deepssm_error').getData()
+                                }
 
                                 if (data) {
                                     let normalizeRange;

--- a/web/shapeworks/src/components/ShapeViewer/methods.js
+++ b/web/shapeworks/src/components/ShapeViewer/methods.js
@@ -415,6 +415,10 @@ export default {
             this.prepareColorScale(canvas, labels, range)
         } else {
             Object.entries(this.data).forEach(([, data], i) => {
+                // if the shape (vtk only) doesn't have the deepssm_error array, don't show the color scale
+                if (data[0].shape.filter((shape) => shape.getClassName() === 'vtkPolyData' && !shape.getPointData().getArrayByName('deepssm_error')).length > 0) {
+                    return;
+                }
                 const [, y1, x2, y2] = this.grid[i]
                 const canvas = document.createElement('canvas')
                 canvas.style.top = `calc(${(1 - y2) * 100}%)`
@@ -432,10 +436,11 @@ export default {
                 let range = [-5, 5]
                 data[0].shape.forEach((shape) => {
                     if (shape.getClassName() === 'vtkPolyData') {
-                        const arr = shape.getPointData().getArrayByName('deepssm_error').getData()
-                        if (arr) range = [Math.min(...arr), Math.max(...arr)]
+                            const arr = shape.getPointData().getArrayByName('deepssm_error').getData()
+                            if (arr) range = [Math.min(...arr), Math.max(...arr)]
+                        } 
                     }
-                })
+                )
                 this.prepareColorScale(canvas, labels, range)
             })
         }


### PR DESCRIPTION
Adds a check to see if the shapedata (.vtk files) have `deepssm_error` and do not render the color bar (non-uniform scale only)

Currently there is an error thrown if the user selects non-uniform scale on the training tab only.

Tested locally by choosing an index to pretend it doesn't have `deepssm_error`. Should simply not render the heatmap or color scale.